### PR TITLE
DCMAW-7696: Add android network module to common repository

### DIFF
--- a/.github/workflows/on_push-main.yml
+++ b/.github/workflows/on_push-main.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Release package
         uses: ./config/actions/maven-publish
         with:
-          access-token: ${{ secrets.TOKEN }}
+          access-token: ${{ secrets.GITHUB_TOKEN }}
           package-version: ${{ steps.version-name.outputs.version-name }}
           username: ${{ github.actor }}
 


### PR DESCRIPTION
- Revert to use GITHUB_TOKEN env for github publish