### PR TITLE
DCMAW-7696: Add android network module to common repository

### DIFF
--- a/network/build.gradle.kts
+++ b/network/build.gradle.kts
@@ -146,7 +146,7 @@ publishing {
     }
     repositories {
         maven(
-            "https://maven.pkg.github.com/govuk-one-login/mobile-android-network",
+            "https://maven.pkg.github.com/govuk-one-login/mobile-android-networking",
             setupGithubCredentials()
         )
     }


### PR DESCRIPTION
- Supply correct repo url to maven publish action