### PR TITLE
ci: Enable dependabot to update the pipelines submodule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,10 @@ updates:
       interval: "daily"
     commit-message:
       prefix: "ci"
+
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "build"


### PR DESCRIPTION
Enable dependabot to update the mobile-android-pipelines submodule (by enabling it to update any git submodule).