### PR TITLE
fix: DCMAW 12035 Fix ktor logging library exposure

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,4 @@
 [versions]
-appcompat = "1.7.0"
 coreKtx = "1.13.1"
 espressoCore = "3.6.1"
 junit = "5.12.1"
@@ -11,7 +10,6 @@ mockitoCore = "5.17.0"
 mockitoKotlin = "5.4.0"
 
 [libraries]
-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
 core-ktx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
 espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espressoCore" }
 ext-junit = { module = "androidx.test.ext:junit", version.ref = "junitVersion" }

--- a/network/build.gradle.kts
+++ b/network/build.gradle.kts
@@ -63,7 +63,6 @@ android {
 dependencies {
     listOf(
         libs.core.ktx,
-        libs.appcompat,
         libs.ktor.client.android,
         libs.ktor.client.core,
         libs.ktor.client.contentnegotiation,

--- a/network/src/main/java/uk/gov/android/network/client/KtorHttpClient.kt
+++ b/network/src/main/java/uk/gov/android/network/client/KtorHttpClient.kt
@@ -10,9 +10,7 @@ import io.ktor.client.plugins.ResponseException
 import io.ktor.client.plugins.UserAgent
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.logging.LogLevel
-import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
-import io.ktor.client.plugins.logging.SIMPLE
 import io.ktor.client.request.forms.FormDataContent
 import io.ktor.client.request.get
 import io.ktor.client.request.headers
@@ -32,6 +30,8 @@ import uk.gov.android.network.auth.AuthenticationProvider
 import uk.gov.android.network.auth.AuthenticationResponse.Failure
 import uk.gov.android.network.auth.AuthenticationResponse.Success
 import uk.gov.android.network.client.HttpStatusCodeExtensions.TransportError
+import uk.gov.android.network.log.KtorLogger
+import uk.gov.android.network.log.KtorLoggerAdapter
 import uk.gov.android.network.useragent.UserAgentGenerator
 
 @Suppress("TooGenericExceptionCaught")
@@ -39,7 +39,7 @@ class KtorHttpClient
     @VisibleForTesting
     constructor(
         userAgentGenerator: UserAgentGenerator,
-        logger: Logger,
+        logger: KtorLogger,
         ktorClientEngine: HttpClientEngine,
     ) : GenericHttpClient {
         private val httpClient: HttpClient =
@@ -52,7 +52,7 @@ class KtorHttpClient
 
         constructor(
             userAgentGenerator: UserAgentGenerator,
-            logger: Logger = if (BuildConfig.DEBUG) Logger.SIMPLE else NoOpLogger(),
+            logger: KtorLogger = if (BuildConfig.DEBUG) KtorLogger.Simple else KtorLogger.NoOp,
         ) : this(
             userAgentGenerator = userAgentGenerator,
             logger = logger,
@@ -61,7 +61,7 @@ class KtorHttpClient
 
         private fun makeHttpClient(
             userAgentGenerator: UserAgentGenerator,
-            logger: Logger,
+            logger: KtorLogger,
             ktorClientEngine: HttpClientEngine,
         ): HttpClient {
             return HttpClient(ktorClientEngine) {
@@ -82,7 +82,7 @@ class KtorHttpClient
                 }
 
                 install(Logging) {
-                    this.logger = logger
+                    this.logger = KtorLoggerAdapter(logger)
                     level = LogLevel.ALL
                 }
 

--- a/network/src/main/java/uk/gov/android/network/client/NoOpLogger.kt
+++ b/network/src/main/java/uk/gov/android/network/client/NoOpLogger.kt
@@ -1,7 +1,0 @@
-package uk.gov.android.network.client
-
-import io.ktor.client.plugins.logging.Logger
-
-class NoOpLogger : Logger {
-    override fun log(message: String) = Unit // Do nothing
-}

--- a/network/src/main/java/uk/gov/android/network/log/KtorLogger.kt
+++ b/network/src/main/java/uk/gov/android/network/log/KtorLogger.kt
@@ -1,0 +1,15 @@
+package uk.gov.android.network.log
+
+interface KtorLogger {
+    fun log(message: String)
+
+    object NoOp : KtorLogger {
+        override fun log(message: String) = Unit // Do nothing
+    }
+
+    object Simple : KtorLogger {
+        override fun log(message: String) {
+            println("HttpClient: $message")
+        }
+    }
+}

--- a/network/src/main/java/uk/gov/android/network/log/KtorLoggerAdapter.kt
+++ b/network/src/main/java/uk/gov/android/network/log/KtorLoggerAdapter.kt
@@ -1,0 +1,9 @@
+package uk.gov.android.network.log
+
+internal class KtorLoggerAdapter(
+    private val logger: KtorLogger,
+) : io.ktor.client.plugins.logging.Logger {
+    override fun log(message: String) {
+        logger.log(message)
+    }
+}

--- a/network/src/test/java/uk/gov/android/network/client/KtorAuthHttpClientTest.kt
+++ b/network/src/test/java/uk/gov/android/network/client/KtorAuthHttpClientTest.kt
@@ -13,6 +13,7 @@ import uk.gov.android.network.api.ApiResponse
 import uk.gov.android.network.auth.AuthenticationResponse.Failure
 import uk.gov.android.network.auth.AuthenticationResponse.Success
 import uk.gov.android.network.auth.MockAuthenticationProvider
+import uk.gov.android.network.log.KtorLogger
 import uk.gov.android.network.useragent.UserAgentGeneratorStub
 
 class KtorAuthHttpClientTest {
@@ -37,7 +38,7 @@ class KtorAuthHttpClientTest {
         sut =
             KtorHttpClient(
                 userAgentGenerator = userAgentGenerator,
-                logger = NoOpLogger(),
+                logger = KtorLogger.NoOp,
                 ktorClientEngine = mockEngine,
             )
         val expectedBearerToken = "ExpectedBearerToken"
@@ -82,7 +83,7 @@ class KtorAuthHttpClientTest {
         sut =
             KtorHttpClient(
                 userAgentGenerator = userAgentGenerator,
-                logger = NoOpLogger(),
+                logger = KtorLogger.NoOp,
                 ktorClientEngine = mockEngine,
             )
         val expectedBearerToken = "ExpectedBearerToken"
@@ -180,7 +181,7 @@ class KtorAuthHttpClientTest {
         sut =
             KtorHttpClient(
                 userAgentGenerator = userAgentGenerator,
-                logger = NoOpLogger(),
+                logger = KtorLogger.NoOp,
                 ktorClientEngine = mockEngine,
             )
         val expectedBearerToken = "ExpectedBearerToken"

--- a/network/src/test/java/uk/gov/android/network/client/KtorHttpClientTest.kt
+++ b/network/src/test/java/uk/gov/android/network/client/KtorHttpClientTest.kt
@@ -12,6 +12,7 @@ import uk.gov.android.network.api.ApiRequest
 import uk.gov.android.network.api.ApiResponse
 import uk.gov.android.network.api.ApiResponseException
 import uk.gov.android.network.client.HttpStatusCodeExtensions.TransportError
+import uk.gov.android.network.log.KtorLogger
 import uk.gov.android.network.useragent.UserAgentGeneratorStub
 
 class KtorHttpClientTest {
@@ -26,7 +27,7 @@ class KtorHttpClientTest {
         sut =
             KtorHttpClient(
                 userAgentGenerator = userAgentGenerator,
-                logger = NoOpLogger(),
+                logger = KtorLogger.NoOp,
                 ktorClientEngine =
                     MockEngine {
                         respond(
@@ -50,7 +51,7 @@ class KtorHttpClientTest {
         sut =
             KtorHttpClient(
                 userAgentGenerator = userAgentGenerator,
-                logger = NoOpLogger(),
+                logger = KtorLogger.NoOp,
                 ktorClientEngine =
                     MockEngine {
                         respond(
@@ -76,7 +77,7 @@ class KtorHttpClientTest {
         sut =
             KtorHttpClient(
                 userAgentGenerator = userAgentGenerator,
-                logger = NoOpLogger(),
+                logger = KtorLogger.NoOp,
                 ktorClientEngine =
                     MockEngine {
                         throw IllegalStateException(errorMessage)
@@ -101,7 +102,7 @@ class KtorHttpClientTest {
         sut =
             KtorHttpClient(
                 userAgentGenerator = userAgentGenerator,
-                logger = NoOpLogger(),
+                logger = KtorLogger.NoOp,
                 ktorClientEngine =
                     MockEngine {
                         respond(
@@ -133,7 +134,7 @@ class KtorHttpClientTest {
         sut =
             KtorHttpClient(
                 userAgentGenerator = userAgentGenerator,
-                logger = NoOpLogger(),
+                logger = KtorLogger.NoOp,
                 ktorClientEngine =
                     MockEngine {
                         respond(
@@ -165,7 +166,7 @@ class KtorHttpClientTest {
         sut =
             KtorHttpClient(
                 userAgentGenerator = userAgentGenerator,
-                logger = NoOpLogger(),
+                logger = KtorLogger.NoOp,
                 ktorClientEngine =
                     MockEngine {
                         respond(
@@ -200,7 +201,7 @@ class KtorHttpClientTest {
         sut =
             KtorHttpClient(
                 userAgentGenerator = userAgentGenerator,
-                logger = NoOpLogger(),
+                logger = KtorLogger.NoOp,
                 ktorClientEngine =
                     MockEngine {
                         throw IllegalStateException(errorMessage)
@@ -231,7 +232,7 @@ class KtorHttpClientTest {
         sut =
             KtorHttpClient(
                 userAgentGenerator = userAgentGenerator,
-                logger = NoOpLogger(),
+                logger = KtorLogger.NoOp,
                 ktorClientEngine =
                     MockEngine {
                         respond(
@@ -265,7 +266,7 @@ class KtorHttpClientTest {
         sut =
             KtorHttpClient(
                 userAgentGenerator = userAgentGenerator,
-                logger = NoOpLogger(),
+                logger = KtorLogger.NoOp,
                 ktorClientEngine =
                     MockEngine {
                         respond(
@@ -294,7 +295,7 @@ class KtorHttpClientTest {
         sut =
             KtorHttpClient(
                 userAgentGenerator = userAgentGenerator,
-                logger = NoOpLogger(),
+                logger = KtorLogger.NoOp,
                 ktorClientEngine =
                     MockEngine {
                         respond(
@@ -326,7 +327,7 @@ class KtorHttpClientTest {
         sut =
             KtorHttpClient(
                 userAgentGenerator = userAgentGenerator,
-                logger = NoOpLogger(),
+                logger = KtorLogger.NoOp,
                 ktorClientEngine =
                     MockEngine {
                         throw IllegalStateException(errorMessage)

--- a/network/src/test/java/uk/gov/android/network/log/KtorLoggerAdapterTest.kt
+++ b/network/src/test/java/uk/gov/android/network/log/KtorLoggerAdapterTest.kt
@@ -1,0 +1,18 @@
+package uk.gov.android.network.log
+
+import io.ktor.client.plugins.logging.Logger
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+class KtorLoggerAdapterTest {
+    @Test
+    fun `KtorLoggerAdapter should delegate to custom KtorLogger`() {
+        val mockLogger = mock<KtorLogger>()
+        val adapter: Logger = KtorLoggerAdapter(mockLogger)
+        val testMessage = "adapter test"
+
+        adapter.log(testMessage)
+        verify(mockLogger).log(testMessage)
+    }
+}

--- a/network/src/test/java/uk/gov/android/network/log/KtorLoggerTest.kt
+++ b/network/src/test/java/uk/gov/android/network/log/KtorLoggerTest.kt
@@ -1,0 +1,33 @@
+package uk.gov.android.network.log
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+
+class KtorLoggerTest {
+    @Test
+    fun `NoOp logger should not throw exception`() {
+        val logger = KtorLogger.NoOp
+        Assertions.assertDoesNotThrow {
+            logger.log("This should do nothing")
+        }
+    }
+
+    @Test
+    fun `Simple logger should print message to stdout`() {
+        val logger = KtorLogger.Simple
+        val outputStream = ByteArrayOutputStream()
+        val originalOut = System.out
+        System.setOut(PrintStream(outputStream))
+
+        try {
+            val testMessage = "Test message"
+            logger.log(testMessage)
+            val output = outputStream.toString().trim()
+            Assertions.assertEquals("HttpClient: $testMessage", output)
+        } finally {
+            System.setOut(originalOut)
+        }
+    }
+}


### PR DESCRIPTION
# _Fix ktor logging library exposure_

- Remove unused dependency appCompat
- Add log package
- Add KtorLogger interface with inner objects Simple and NoOp
- Add KtorLoggerAdapter class for adapting KtorLoggers to the Ktor Logging interface
- Add testing throughout

## JIRA ticket link:

- [DCMAW-12035](https://govukverify.atlassian.net/browse/DCMAW-12035)

## Evidence of the change:

- None

## Checklist

### Before creating the pull request

- [x] Commit messages that conform to conventional commit messages.
- [x] Tests pass locally.
- [x] Pull request has a clear title with a short description about the feature or update.
- [x] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [x] Complete all Acceptance Criteria within Jira ticket.
- [x] Self-review code.
- [x] Complete automated Testing:
  * [x] Unit Tests.
  * [x] Integration Tests.
  * [x] Instrumentation / Emulator Tests.
- [ ] Handle PR comments.

### Before merging the pull request

- [ ] For **Defect**, **Tech Story** and **Story** tickets: Ensure that QA has reviewed (by checking they have the correct links to the correct JIRA tickets, the correct amount of details in the PR description to match the JIRA ticket, screenshot/video evidence attached when necessary) and commented QA approval.
- [ ] For **Tech Debt**, **Task** and **Spike** tickets (dev-only): Ensure that developer has reviewed (by checking they have the correct links to the correct JIRA tickets, the correct amount of details in the PR description to match the JIRA ticket, screenshot/video evidence attached when necessary) and commented Dev QA approval.
- [ ] [Sonar cloud report] passes inspections for your PR.
- [ ] Resolve all comments.

[Sonar cloud report]: https://sonarcloud.io/project/overview?id=mobile-android-networking
