### PR TITLE
fix: Fix group ID of test fixture publications

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,3 +46,8 @@ plugins {
     id("uk.gov.pipelines.vale-config")
     id("uk.gov.pipelines.sonarqube-root-config")
 }
+
+subprojects {
+    val mavenGroupId: String by rootProject.extra
+    group = mavenGroupId
+}


### PR DESCRIPTION
## Changes

- Set `Project.group` in all projects

## Context

Fixes an issue where test fixtures can't be resolved.

I also considered improving the default behaviour for all projects upstream in mobile-android-pipelines. But decided against in case it interferes with how projects are customising the Maven Publishing plugin group ID later in the build.

DCMAW-20640

## Evidence of the change

Tested manually by publishing locally and then consuming the test fixtures from Maven local repository.

```sh
./gradlew publishToMavenLocal
```

## Checklist

### Before creating the pull request

- [ ] Commit messages that conform to conventional commit messages.
- [ ] Tests pass locally.
- [ ] Pull request has a clear title with a short description about the feature or update.
- [ ] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [ ] Complete all Acceptance Criteria within Jira ticket.
- [ ] Self-review code.
- [ ] Complete automated Testing:
  * [ ] Unit Tests.
  * [ ] Integration Tests.
  * [ ] Instrumentation / Emulator Tests.
- [ ] Handle PR comments.

### Before merging the pull request

- [ ] For **Defect**, **Tech Story** and **Story** tickets: Ensure that QA has reviewed (by checking they have the correct links to the correct JIRA tickets, the correct amount of details in the PR description to match the JIRA ticket, screenshot/video evidence attached when necessary) and commented QA approval.
- [ ] For **Tech Debt**, **Task** and **Spike** tickets (dev-only): Ensure that developer has reviewed (by checking they have the correct links to the correct JIRA tickets, the correct amount of details in the PR description to match the JIRA ticket, screenshot/video evidence attached when necessary) and commented Dev QA approval.
- [ ] [Sonar cloud report] passes inspections for your PR.
- [ ] Resolve all comments.

[Sonar cloud report]: https://sonarcloud.io/project/overview?id=mobile-android-networking
