### PR TITLE
feat: Add support for client attestation and DPoP headers

### DIFF
--- a/network/src/main/java/uk/gov/android/network/client/headers/AttestationHeaderReader.kt
+++ b/network/src/main/java/uk/gov/android/network/client/headers/AttestationHeaderReader.kt
@@ -1,0 +1,53 @@
+package uk.gov.android.network.client.headers
+
+import uk.gov.android.network.attestation.ClientAttestationProvider
+import uk.gov.android.network.attestation.ClientAttestationResponse
+import uk.gov.android.network.http.Header
+import uk.gov.android.network.service.ConfigurationException
+import uk.gov.android.network.service.ServiceException
+import uk.gov.android.network.util.NetworkingResult
+
+private const val ATTESTATION_HEADER_KEY = "OAuth-Client-Attestation"
+private const val ATTESTATION_POP_HEADER_KEY = "OAuth-Client-Attestation-PoP"
+
+internal class AttestationHeaderReader(
+    internal val clientAttestationProvider: ClientAttestationProvider?,
+) {
+    @Suppress(
+        // This function uses the return early pattern for different types of failure.
+        // There is only one return statement for success, which is the final statement.
+        "ReturnCount",
+    )
+    suspend fun getHeaders(): NetworkingResult<List<Header>> {
+        val provider =
+            this.clientAttestationProvider ?: return missingProviderFailure()
+
+        val response = provider.getClientAttestation()
+        val headers =
+            when (response) {
+                is ClientAttestationResponse.Failure -> return response.attestationFailure()
+                is ClientAttestationResponse.Success -> response.toAttestationHeaders()
+            }
+
+        return NetworkingResult.Success(headers)
+    }
+
+    private fun missingProviderFailure() =
+        NetworkingResult.Failure<List<Header>>(
+            ConfigurationException("ClientAttestationProvider not set"),
+        )
+
+    private fun ClientAttestationResponse.Failure.attestationFailure() =
+        NetworkingResult.Failure<List<Header>>(
+            ServiceException(
+                "Attestation provider failed to fetch client attestation",
+                error,
+            ),
+        )
+}
+
+internal fun ClientAttestationResponse.Success.toAttestationHeaders(): List<Header> =
+    listOf(
+        Header(ATTESTATION_HEADER_KEY, clientAttestation),
+        Header(ATTESTATION_POP_HEADER_KEY, attestationPop),
+    )

--- a/network/src/main/java/uk/gov/android/network/client/headers/RefreshDPoPHeaderReader.kt
+++ b/network/src/main/java/uk/gov/android/network/client/headers/RefreshDPoPHeaderReader.kt
@@ -1,0 +1,48 @@
+package uk.gov.android.network.client.headers
+
+import uk.gov.android.network.dpop.DPoPProvider
+import uk.gov.android.network.dpop.DPoPResponse
+import uk.gov.android.network.http.Header
+import uk.gov.android.network.service.ConfigurationException
+import uk.gov.android.network.service.ServiceException
+import uk.gov.android.network.util.NetworkingResult
+
+private const val DPOP_HEADER_KEY = "DPoP"
+
+internal class RefreshDPoPHeaderReader(
+    internal val dpopProvider: DPoPProvider?,
+) {
+    @Suppress(
+        // This function uses the return early pattern for different types of failure.
+        // There is only one return statement for success, which is the final statement.
+        "ReturnCount",
+    )
+    suspend fun getHeader(): NetworkingResult<Header> {
+        val provider =
+            this.dpopProvider ?: return missingProviderFailure()
+
+        val response = provider.getRefreshDPoP()
+        val header =
+            when (response) {
+                is DPoPResponse.Failure -> return response.dpopFailure()
+                is DPoPResponse.Success -> response.toDPoPHeader()
+            }
+
+        return NetworkingResult.Success(header)
+    }
+
+    private fun missingProviderFailure() =
+        NetworkingResult.Failure<Header>(
+            ConfigurationException("DPoPProvider not set"),
+        )
+
+    private fun DPoPResponse.Failure.dpopFailure() =
+        NetworkingResult.Failure<Header>(
+            ServiceException(
+                "DPoP provider failed to fetch refresh DPoP proof",
+                error,
+            ),
+        )
+}
+
+internal fun DPoPResponse.Success.toDPoPHeader(): Header = Header(DPOP_HEADER_KEY, dpop)

--- a/network/src/main/java/uk/gov/android/network/service/DefaultNetworkingService.kt
+++ b/network/src/main/java/uk/gov/android/network/service/DefaultNetworkingService.kt
@@ -4,12 +4,16 @@ import kotlinx.io.IOException
 import uk.gov.android.network.api.v2.ApiRequest
 import uk.gov.android.network.api.v2.ApiResponse
 import uk.gov.android.network.api.v2.withHeaders
+import uk.gov.android.network.attestation.ClientAttestationProvider
 import uk.gov.android.network.auth.AuthenticationProvider
 import uk.gov.android.network.client.config.RequestConfig
 import uk.gov.android.network.client.config.RequestConfigBuilder
+import uk.gov.android.network.client.headers.AttestationHeaderReader
 import uk.gov.android.network.client.headers.AuthorisationHeaderReader
+import uk.gov.android.network.client.headers.RefreshDPoPHeaderReader
 import uk.gov.android.network.client.v2.GenericHttpClient
 import uk.gov.android.network.client.v2.GenericResponseException
+import uk.gov.android.network.dpop.DPoPProvider
 import uk.gov.android.network.http.Header
 import uk.gov.android.network.util.ExcludeFromJacocoGeneratedReport
 import uk.gov.android.network.util.NetworkingResult
@@ -24,7 +28,9 @@ import uk.gov.android.network.util.NetworkingResult
 class DefaultNetworkingService(
     private val httpClient: GenericHttpClient,
 ) : NetworkingService {
+    private var attestationHeaderReader = AttestationHeaderReader(null)
     private var authorisationHeaderReader = AuthorisationHeaderReader(null)
+    private var refreshDPoPHeaderReader = RefreshDPoPHeaderReader(null)
 
     @Suppress(
         // This function uses the return early pattern for different types of failure.
@@ -68,12 +74,28 @@ class DefaultNetworkingService(
         authorisationHeaderReader = AuthorisationHeaderReader(authenticationProvider)
     }
 
+    fun setClientAttestationProvider(clientAttestationProvider: ClientAttestationProvider?) {
+        attestationHeaderReader = AttestationHeaderReader(clientAttestationProvider)
+    }
+
+    fun setDPoPProvider(dpopProvider: DPoPProvider?) {
+        refreshDPoPHeaderReader = RefreshDPoPHeaderReader(dpopProvider)
+    }
+
+    @Suppress(
+        // This function uses the return early pattern for different types of failure.
+        // There is only one return statement for success, which is the final statement.
+        "ReturnCount",
+    )
     private suspend fun buildExtraHeaders(config: RequestConfig): NetworkingResult<List<Header>> {
-        val attestationHeader =
+        val attestationHeaders =
             if (config.attestation) {
-                error("Not yet implemented")
+                when (val result = attestationHeaderReader.getHeaders()) {
+                    is NetworkingResult.Failure -> return NetworkingResult.Failure(result.exception)
+                    is NetworkingResult.Success -> result.value
+                }
             } else {
-                null
+                emptyList()
             }
 
         val authHeader =
@@ -90,17 +112,20 @@ class DefaultNetworkingService(
 
         val refreshDPoPHeader =
             if (config.refreshDPoP) {
-                error("Not yet implemented")
+                when (val result = refreshDPoPHeaderReader.getHeader()) {
+                    is NetworkingResult.Failure -> return NetworkingResult.Failure(result.exception)
+                    is NetworkingResult.Success -> result.value
+                }
             } else {
                 null
             }
 
         return NetworkingResult.Success(
-            listOfNotNull(
-                attestationHeader,
-                authHeader,
-                refreshDPoPHeader,
-            ),
+            attestationHeaders +
+                listOfNotNull(
+                    authHeader,
+                    refreshDPoPHeader,
+                ),
         )
     }
 

--- a/network/src/test/java/uk/gov/android/network/client/headers/AttestationHeaderReaderTest.kt
+++ b/network/src/test/java/uk/gov/android/network/client/headers/AttestationHeaderReaderTest.kt
@@ -1,0 +1,67 @@
+package uk.gov.android.network.client.headers
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Test
+import uk.gov.android.network.attestation.TestClientAttestationProvider
+import uk.gov.android.network.attestation.clientAttestationFailure
+import uk.gov.android.network.attestation.clientAttestationSuccess
+import uk.gov.android.network.service.ConfigurationException
+import uk.gov.android.network.service.ServiceException
+import uk.gov.android.network.util.expectFailure
+import uk.gov.android.network.util.expectSuccess
+import kotlin.jvm.java
+
+class AttestationHeaderReaderTest {
+    private val provider = TestClientAttestationProvider()
+    private val headerReader = AttestationHeaderReader(provider)
+
+    @Test
+    fun `given provider is null, getHeaders returns missing provider failure`() =
+        runTest {
+            val headerReader = AttestationHeaderReader(null)
+
+            val result = headerReader.getHeaders()
+
+            assertInstanceOf(ConfigurationException::class.java, result.expectFailure())
+        }
+
+    @Test
+    fun `given provider returns failure, getHeaders returns attestation failure`() =
+        runTest {
+            provider.response = clientAttestationFailure
+
+            val result = headerReader.getHeaders()
+
+            assertInstanceOf(ServiceException::class.java, result.expectFailure())
+        }
+
+    @Test
+    fun `given provider returns success, getHeaders returns attestation headers`() =
+        runTest {
+            val result = headerReader.getHeaders()
+
+            assertEquals(
+                listOf(
+                    "OAuth-Client-Attestation" to "client-attestation-jwt",
+                    "OAuth-Client-Attestation-PoP" to "attestation-pop-jwt",
+                ),
+                result.expectSuccess(),
+            )
+        }
+
+    @Test
+    fun `given successful attestation response, toAttestationHeaders formats headers`() =
+        runTest {
+            val result = clientAttestationSuccess.toAttestationHeaders()
+
+            assertEquals(
+                listOf(
+                    "OAuth-Client-Attestation" to "client-attestation-jwt",
+                    "OAuth-Client-Attestation-PoP" to "attestation-pop-jwt",
+                ),
+                result,
+            )
+        }
+}

--- a/network/src/test/java/uk/gov/android/network/client/headers/RefreshDPoPHeaderReaderTest.kt
+++ b/network/src/test/java/uk/gov/android/network/client/headers/RefreshDPoPHeaderReaderTest.kt
@@ -1,0 +1,54 @@
+package uk.gov.android.network.client.headers
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Test
+import uk.gov.android.network.dpop.TestDPoPProvider
+import uk.gov.android.network.dpop.dpopFailure
+import uk.gov.android.network.dpop.dpopSuccess
+import uk.gov.android.network.service.ConfigurationException
+import uk.gov.android.network.service.ServiceException
+import uk.gov.android.network.util.expectFailure
+import uk.gov.android.network.util.expectSuccess
+
+class RefreshDPoPHeaderReaderTest {
+    private val provider = TestDPoPProvider()
+    private val headerReader = RefreshDPoPHeaderReader(provider)
+
+    @Test
+    fun `given provider is null, getHeader returns missing provider failure`() =
+        runTest {
+            val headerReader = RefreshDPoPHeaderReader(null)
+
+            val result = headerReader.getHeader()
+
+            assertInstanceOf(ConfigurationException::class.java, result.expectFailure())
+        }
+
+    @Test
+    fun `given provider returns failure, getHeader returns dpop failure`() =
+        runTest {
+            provider.response = dpopFailure
+
+            val result = headerReader.getHeader()
+
+            assertInstanceOf(ServiceException::class.java, result.expectFailure())
+        }
+
+    @Test
+    fun `given provider returns success, getHeader returns dpop header`() =
+        runTest {
+            val result = headerReader.getHeader()
+
+            assertEquals("DPoP" to "dpop-proof-jwt", result.expectSuccess())
+        }
+
+    @Test
+    fun `given successful dpop response, toDPoPHeader formats header`() =
+        runTest {
+            val result = dpopSuccess.toDPoPHeader()
+
+            assertEquals("DPoP" to "dpop-proof-jwt", result)
+        }
+}

--- a/network/src/test/java/uk/gov/android/network/service/DefaultNetworkingServiceTest.kt
+++ b/network/src/test/java/uk/gov/android/network/service/DefaultNetworkingServiceTest.kt
@@ -8,17 +8,24 @@ import org.junit.jupiter.api.Test
 import uk.gov.android.network.api.v2.ApiRequest
 import uk.gov.android.network.api.v2.ApiResponse
 import uk.gov.android.network.api.v2.expectFailure
+import uk.gov.android.network.attestation.TestClientAttestationProvider
+import uk.gov.android.network.attestation.clientAttestationFailure
 import uk.gov.android.network.auth.TestAuthenticationProvider
 import uk.gov.android.network.auth.authenticationFailure
 import uk.gov.android.network.client.v2.StubHttpClient
 import uk.gov.android.network.client.v2.TestHttpResponse
 import uk.gov.android.network.client.v2.TestResponseException
+import uk.gov.android.network.dpop.TestDPoPProvider
+import uk.gov.android.network.dpop.dpopFailure
+import kotlin.jvm.java
 
 class DefaultNetworkingServiceTest {
     private val httpClient = StubHttpClient()
     private val networkingService = DefaultNetworkingService(httpClient = httpClient)
     private val request = ApiRequest.Get(url = "https://example.com")
     private val authProvider = TestAuthenticationProvider(expectedScope = SCOPE)
+    private val attestationProvider = TestClientAttestationProvider()
+    private val dpopProvider = TestDPoPProvider()
 
     @Test
     fun `given client returns response, makeRequest returns success with body and status`() =
@@ -96,6 +103,79 @@ class DefaultNetworkingServiceTest {
             networkingService.makeRequest(request)
 
             assertEquals(request, httpClient.receivedRequest)
+        }
+
+    @Test
+    fun `given attestation configured and header reader fails, makeRequest returns failure`() =
+        runTest {
+            attestationProvider.response = clientAttestationFailure
+            networkingService.setClientAttestationProvider(attestationProvider)
+            httpClient.response = TestHttpResponse.success
+
+            val result =
+                networkingService.makeRequest(request) {
+                    withAttestation = true
+                }
+
+            val failure = result.expectFailure()
+            assertInstanceOf(ServiceException::class.java, failure.error)
+        }
+
+    @Test
+    fun `given attestation configured, makeRequest appends attestation headers`() =
+        runTest {
+            networkingService.setClientAttestationProvider(attestationProvider)
+            httpClient.response = TestHttpResponse.success
+
+            networkingService.makeRequest(request) {
+                withAttestation = true
+            }
+
+            assertEquals(
+                request.copy(
+                    headers =
+                        request.headers +
+                            listOf(
+                                "OAuth-Client-Attestation" to "client-attestation-jwt",
+                                "OAuth-Client-Attestation-PoP" to "attestation-pop-jwt",
+                            ),
+                ),
+                httpClient.receivedRequest,
+            )
+        }
+
+    @Test
+    fun `given refreshDPoP configured and header reader fails, makeRequest returns failure`() =
+        runTest {
+            dpopProvider.response = dpopFailure
+            networkingService.setDPoPProvider(dpopProvider)
+            httpClient.response = TestHttpResponse.success
+
+            val result =
+                networkingService.makeRequest(request) {
+                    withRefreshDPoP = true
+                }
+
+            val failure = result.expectFailure()
+            assertInstanceOf(ServiceException::class.java, failure.error)
+        }
+
+    @Test
+    fun `given refreshDPoP configured, makeRequest appends DPoP header`() =
+        runTest {
+            networkingService.setDPoPProvider(dpopProvider)
+            httpClient.response = TestHttpResponse.success
+
+            networkingService.makeRequest(request) {
+                withRefreshDPoP = true
+            }
+
+            assertEquals(
+                request.copy(
+                    headers = request.headers + ("DPoP" to "dpop-proof-jwt"),
+                ),
+                httpClient.receivedRequest,
+            )
         }
 
     companion object {


### PR DESCRIPTION
## Context

Continuation of #311, adding support for client attestation and DPoP headers

## Evidence of the change:

[//]: # (Screenshots / uploaded videos go here)

## Checklist

### Before creating the pull request

- [ ] Commit messages that conform to conventional commit messages.
- [ ] Tests pass locally.
- [ ] Pull request has a clear title with a short description about the feature or update.
- [ ] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [ ] Complete all Acceptance Criteria within Jira ticket.
- [ ] Self-review code.
- [ ] Complete automated Testing:
  * [ ] Unit Tests.
  * [ ] Integration Tests.
  * [ ] Instrumentation / Emulator Tests.
- [ ] Handle PR comments.

### Before merging the pull request

- [ ] For **Defect**, **Tech Story** and **Story** tickets: Make sure that QA has reviewed (by checking they have the correct links to the correct JIRA tickets, the correct amount of details in the PR description to match the JIRA ticket, screenshot/video evidence attached when necessary) and commented QA approval.
- [ ] For **Tech Debt**, **Task** and **Spike** tickets (dev-only): Make sure that developer has reviewed (by checking they have the correct links to the correct JIRA tickets, the correct amount of details in the PR description to match the JIRA ticket, screenshot/video evidence attached when necessary) and commented Dev QA approval.
- [ ] [Sonar cloud report] passes inspections for your PR.
- [ ] Resolve all comments.

[Sonar cloud report]: https://sonarcloud.io/project/overview?id=mobile-android-networking
