### PR TITLE
feat: enforce TLS 1.2 minimum on all Android versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,8 @@ kotlinSerializationPlugin = "2.3.21"
 ktor = "3.5.0"
 mockitoCore = "5.23.0"
 mockitoKotlin = "6.3.0"
+mockwebserver = "5.3.2"
+androidXTestOrchestrator = "1.6.1"
 kotlin = "2.3.21"
 
 [libraries]
@@ -15,6 +17,9 @@ espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref =
 ext-junit = { module = "androidx.test.ext:junit", version.ref = "junitVersion" }
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockitoCore" }
 mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockitoKotlin" }
+mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "mockwebserver" }
+okhttp-tls = { module = "com.squareup.okhttp3:okhttp-tls", version.ref = "mockwebserver" }
+androidx-test-orchestrator = { module = "androidx.test:orchestrator", version.ref = "androidXTestOrchestrator" }
 
 # Kotlin
 kotlin-bom = { group = "org.jetbrains.kotlin", name = "kotlin-bom", version.ref = "kotlin" }

--- a/network/build.gradle.kts
+++ b/network/build.gradle.kts
@@ -100,9 +100,14 @@ dependencies {
     listOf(
         libs.ext.junit,
         libs.espresso.core,
+        libs.mockwebserver,
+        libs.okhttp.tls,
+        libs.kotlinx.coroutines.test,
     ).forEach { dependency ->
         androidTestImplementation(dependency)
     }
+
+    androidTestUtil(libs.androidx.test.orchestrator)
 }
 
 mavenPublishingConfig {

--- a/network/src/androidTest/AndroidManifest.xml
+++ b/network/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+</manifest>

--- a/network/src/androidTest/java/uk/gov/android/network/client/KtorHttpClientTlsTest.kt
+++ b/network/src/androidTest/java/uk/gov/android/network/client/KtorHttpClientTlsTest.kt
@@ -1,0 +1,209 @@
+package uk.gov.android.network.client
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.ktor.client.engine.android.Android
+import kotlinx.coroutines.test.runTest
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.tls.HandshakeCertificates
+import okhttp3.tls.HeldCertificate
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import uk.gov.android.network.api.ApiRequest
+import uk.gov.android.network.api.ApiResponse
+import uk.gov.android.network.log.KtorLogger
+import uk.gov.android.network.useragent.UserAgentGeneratorStub
+import java.net.InetAddress
+import java.net.Socket
+import javax.net.ssl.HostnameVerifier
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLSocket
+import javax.net.ssl.SSLSocketFactory
+
+/**
+ * Instrumentation tests verifying that [Tls12SocketFactory] prevents connections to servers
+ * that only support TLS 1.1 or below.
+ *
+ * These tests exercise [createTls12Engine] with a custom [javax.net.ssl.X509TrustManager] and
+ * [javax.net.ssl.HostnameVerifier] so the client trusts the local MockWebServer's self-signed
+ * certificate. The TLS enforcement logic is identical to production.
+ *
+ * Note: These tests should ideally be run on Android 10–14 (API 29–34) devices. On Android 15+
+ * the platform blocks TLS 1.1 regardless, so the tests will pass even without our enforcement.
+ */
+@RunWith(AndroidJUnit4::class)
+class KtorHttpClientTlsTest {
+    private lateinit var server: MockWebServer
+    private lateinit var heldCertificate: HeldCertificate
+    private lateinit var serverCerts: HandshakeCertificates
+    private lateinit var clientCerts: HandshakeCertificates
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        heldCertificate =
+            HeldCertificate
+                .Builder()
+                .addSubjectAlternativeName("localhost")
+                .build()
+        serverCerts =
+            HandshakeCertificates
+                .Builder()
+                .heldCertificate(heldCertificate)
+                .build()
+        clientCerts =
+            HandshakeCertificates
+                .Builder()
+                .addTrustedCertificate(heldCertificate.certificate)
+                .build()
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun clientRejectsConnectionToTls11OnlyServer() =
+        runTest {
+            server.useHttps(tls11OnlySocketFactory(), false)
+            server.enqueue(MockResponse().setBody("should not reach"))
+            server.start()
+
+            val client =
+                KtorHttpClient(
+                    userAgentGenerator = UserAgentGeneratorStub("test-agent"),
+                    logger = KtorLogger.noOp,
+                    ktorClientEngine =
+                        createKtorAndroidEngine(
+                            trustManager = clientCerts.trustManager,
+                            hostnameVerifier = HostnameVerifier { _, _ -> true },
+                        ),
+                )
+
+            val response =
+                client.makeRequest(
+                    ApiRequest.Get("https://localhost:${server.port}/test"),
+                )
+
+            assertTrue("Expected failure but got: $response", response is ApiResponse.Failure)
+        }
+
+    @Test
+    fun clientConnectsToTls12Server() =
+        runTest {
+            server.useHttps(serverCerts.sslSocketFactory(), false)
+            server.enqueue(MockResponse().setBody("hello"))
+            server.start()
+
+            val client =
+                KtorHttpClient(
+                    userAgentGenerator = UserAgentGeneratorStub("test-agent"),
+                    logger = KtorLogger.noOp,
+                    ktorClientEngine =
+                        createKtorAndroidEngine(
+                            trustManager = clientCerts.trustManager,
+                            hostnameVerifier = HostnameVerifier { _, _ -> true },
+                        ),
+                )
+
+            val response =
+                client.makeRequest(
+                    ApiRequest.Get("https://localhost:${server.port}/test"),
+                )
+
+            assertTrue(
+                "Expected success but got: $response",
+                response is ApiResponse.Success<*>,
+            )
+        }
+
+    @Test
+    fun insecureClientAcceptsConnectionToTls11OnlyServer() =
+        runTest {
+            server.useHttps(tls11OnlySocketFactory(), false)
+            server.enqueue(MockResponse().setBody("connected via tls 1.1"))
+            server.start()
+
+            // Engine without TLS version enforcement
+            val client =
+                KtorHttpClient(
+                    userAgentGenerator = UserAgentGeneratorStub("test-agent"),
+                    logger = KtorLogger.noOp,
+                    ktorClientEngine =
+                        Android.create {
+                            sslManager = { connection ->
+                                connection.sslSocketFactory =
+                                    clientCerts.sslSocketFactory()
+                                connection.hostnameVerifier = { _, _ -> true }
+                            }
+                        },
+                )
+
+            val response =
+                client.makeRequest(
+                    ApiRequest.Get("https://localhost:${server.port}/test"),
+                )
+
+            assertTrue(
+                "Expected success (proving TLS 1.1 works without enforcement) but got: $response",
+                response is ApiResponse.Success<*>,
+            )
+        }
+
+    private fun tls11OnlySocketFactory(): SSLSocketFactory {
+        val sslContext = SSLContext.getInstance("TLS")
+        sslContext.init(
+            arrayOf(serverCerts.keyManager),
+            arrayOf(serverCerts.trustManager),
+            null,
+        )
+        val delegate = sslContext.socketFactory
+        return object : SSLSocketFactory() {
+            override fun getDefaultCipherSuites() = delegate.defaultCipherSuites
+
+            override fun getSupportedCipherSuites() = delegate.supportedCipherSuites
+
+            override fun createSocket() = (delegate.createSocket() as SSLSocket).restrictToTls11()
+
+            override fun createSocket(
+                s: Socket?,
+                host: String?,
+                port: Int,
+                autoClose: Boolean,
+            ) = (delegate.createSocket(s, host, port, autoClose) as SSLSocket)
+                .restrictToTls11()
+
+            override fun createSocket(
+                host: String?,
+                port: Int,
+            ) = (delegate.createSocket(host, port) as SSLSocket).restrictToTls11()
+
+            override fun createSocket(
+                host: String?,
+                port: Int,
+                localHost: InetAddress?,
+                localPort: Int,
+            ) = (delegate.createSocket(host, port, localHost, localPort) as SSLSocket)
+                .restrictToTls11()
+
+            override fun createSocket(
+                host: InetAddress?,
+                port: Int,
+            ) = (delegate.createSocket(host, port) as SSLSocket).restrictToTls11()
+
+            override fun createSocket(
+                address: InetAddress?,
+                port: Int,
+                localAddress: InetAddress?,
+                localPort: Int,
+            ) = (delegate.createSocket(address, port, localAddress, localPort) as SSLSocket)
+                .restrictToTls11()
+
+            private fun SSLSocket.restrictToTls11() = apply { enabledProtocols = arrayOf("TLSv1.1") }
+        }
+    }
+}

--- a/network/src/androidTest/java/uk/gov/android/network/client/KtorHttpClientTlsTest.kt
+++ b/network/src/androidTest/java/uk/gov/android/network/client/KtorHttpClientTlsTest.kt
@@ -20,6 +20,7 @@ import java.net.InetAddress
 import java.net.Socket
 import javax.net.ssl.HostnameVerifier
 import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLException
 import javax.net.ssl.SSLSocket
 import javax.net.ssl.SSLSocketFactory
 
@@ -90,6 +91,12 @@ class KtorHttpClientTlsTest {
                 )
 
             assertTrue("Expected failure but got: $response", response is ApiResponse.Failure)
+            val failure = response as ApiResponse.Failure
+            assertTrue(
+                "Expected SSL-related exception but got: ${failure.error}",
+                failure.error is SSLException ||
+                    failure.error.cause is SSLException,
+            )
         }
 
     @Test

--- a/network/src/main/java/uk/gov/android/network/client/KtorHttpClient.kt
+++ b/network/src/main/java/uk/gov/android/network/client/KtorHttpClient.kt
@@ -51,21 +51,17 @@ class KtorHttpClient
             )
         private var authenticationProvider: AuthenticationProvider? = null
 
+        /**
+         * Production constructor. Uses [createKtorAndroidEngine] to enforce TLS 1.2+ on all
+         * Android versions, including 10–14 where the platform does not restrict it.
+         */
         constructor(
             userAgentGenerator: UserAgentGenerator,
             logger: KtorLogger = if (BuildConfig.DEBUG) KtorLogger.simple else KtorLogger.noOp,
         ) : this(
             userAgentGenerator = userAgentGenerator,
             logger = logger,
-            ktorClientEngine =
-                Android.create {
-                    sslManager = { connection ->
-                        connection.sslSocketFactory =
-                            Tls12SocketFactory(
-                                createTls12SSLContext().socketFactory,
-                            )
-                    }
-                },
+            ktorClientEngine = createKtorAndroidEngine(),
         )
 
         private fun makeHttpClient(
@@ -256,4 +252,20 @@ class KtorHttpClient
             const val AUTH_HEADER_KEY = "Authorization"
             const val AUTH_HEADER_VALUE = "Bearer "
         }
+    }
+
+/**
+ * Creates a Ktor [Android] engine with TLS 1.2+ enforcement via [configureSslManagerMinTls12].
+ *
+ * @param trustManager Optional custom trust manager. Intended only for testing with
+ *   self-signed certificates (e.g. MockWebServer).
+ * @param hostnameVerifier Optional custom hostname verifier. Intended only for testing
+ *   against localhost.
+ */
+internal fun createKtorAndroidEngine(
+    trustManager: javax.net.ssl.X509TrustManager? = null,
+    hostnameVerifier: javax.net.ssl.HostnameVerifier? = null,
+): HttpClientEngine =
+    Android.create {
+        configureSslManagerMinTls12(trustManager, hostnameVerifier)
     }

--- a/network/src/main/java/uk/gov/android/network/client/KtorHttpClient.kt
+++ b/network/src/main/java/uk/gov/android/network/client/KtorHttpClient.kt
@@ -57,7 +57,15 @@ class KtorHttpClient
         ) : this(
             userAgentGenerator = userAgentGenerator,
             logger = logger,
-            ktorClientEngine = Android.create(),
+            ktorClientEngine =
+                Android.create {
+                    sslManager = { connection ->
+                        connection.sslSocketFactory =
+                            Tls12SocketFactory(
+                                createTls12SSLContext().socketFactory,
+                            )
+                    }
+                },
         )
 
         private fun makeHttpClient(

--- a/network/src/main/java/uk/gov/android/network/client/KtorHttpClient.kt
+++ b/network/src/main/java/uk/gov/android/network/client/KtorHttpClient.kt
@@ -34,6 +34,8 @@ import uk.gov.android.network.client.HttpStatusCodeExtensions.TransportError
 import uk.gov.android.network.log.KtorLogger
 import uk.gov.android.network.log.KtorLoggerAdapter
 import uk.gov.android.network.useragent.UserAgentGenerator
+import javax.net.ssl.HostnameVerifier
+import javax.net.ssl.X509TrustManager
 
 @Suppress("TooGenericExceptionCaught")
 class KtorHttpClient
@@ -263,8 +265,8 @@ class KtorHttpClient
  *   against localhost.
  */
 internal fun createKtorAndroidEngine(
-    trustManager: javax.net.ssl.X509TrustManager? = null,
-    hostnameVerifier: javax.net.ssl.HostnameVerifier? = null,
+    trustManager: X509TrustManager? = null,
+    hostnameVerifier: HostnameVerifier? = null,
 ): HttpClientEngine =
     Android.create {
         configureSslManagerMinTls12(trustManager, hostnameVerifier)

--- a/network/src/main/java/uk/gov/android/network/client/Tls12Enforcement.kt
+++ b/network/src/main/java/uk/gov/android/network/client/Tls12Enforcement.kt
@@ -1,17 +1,64 @@
 package uk.gov.android.network.client
 
+import io.ktor.client.engine.android.AndroidEngineConfig
 import java.net.Socket
+import javax.net.ssl.HostnameVerifier
 import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLException
 import javax.net.ssl.SSLSocket
 import javax.net.ssl.SSLSocketFactory
+import javax.net.ssl.X509TrustManager
 
 private val TLS_12_AND_ABOVE = arrayOf("TLSv1.2", "TLSv1.3")
+
+/**
+ * TLS 1.0 and 1.1 are deprecated and blocked by default on Android 15+ (API 35) for apps
+ * targeting that version. However, on Android 10–14 (API 29–34) the platform still permits
+ * these older protocols. This enforcement ensures TLS 1.2+ is required on all supported
+ * Android versions.
+ *
+ * @see <a href="https://developer.android.com/about/versions/15/behavior-changes-15#restricted-tls-versions">
+ *     Android 15 behaviour changes - Restricted TLS versions</a>
+ */
 
 internal fun createTls12SSLContext(): SSLContext =
     SSLContext.getInstance("TLSv1.2").apply {
         init(null, null, null)
     }
 
+/**
+ * Configures the [AndroidEngineConfig] SSL manager to enforce TLS 1.2+ via [Tls12SocketFactory].
+ *
+ * @param trustManager Optional custom trust manager. Intended only for testing with
+ *   self-signed certificates (e.g. MockWebServer). Production callers should use the
+ *   no-arg overload which uses the system default trust.
+ * @param hostnameVerifier Optional custom hostname verifier. Intended only for testing
+ *   against localhost. Production callers should use the no-arg overload which uses the
+ *   system default hostname verification.
+ */
+internal fun AndroidEngineConfig.configureSslManagerMinTls12(
+    trustManager: X509TrustManager? = null,
+    hostnameVerifier: HostnameVerifier? = null,
+) {
+    sslManager = { connection ->
+        val sslContext = createTls12SSLContext()
+        if (trustManager != null) {
+            sslContext.init(null, arrayOf(trustManager), null)
+        }
+        connection.sslSocketFactory = Tls12SocketFactory(sslContext.socketFactory)
+        if (hostnameVerifier != null) {
+            connection.hostnameVerifier = hostnameVerifier
+        }
+    }
+}
+
+/**
+ * An [SSLSocketFactory] wrapper that restricts enabled protocols to TLS 1.2 and TLS 1.3.
+ *
+ * The default SSL context on Android does not restrict which protocols sockets can negotiate —
+ * they can still use TLS 1.0/1.1. The protocol must be explicitly restricted at the socket
+ * level via [SSLSocket.setEnabledProtocols].
+ */
 internal class Tls12SocketFactory(
     private val delegate: SSLSocketFactory,
 ) : SSLSocketFactory() {
@@ -65,4 +112,4 @@ internal class Tls12SocketFactory(
 
 internal class SslRequiredException(
     message: String,
-) : SecurityException(message)
+) : SSLException(message)

--- a/network/src/main/java/uk/gov/android/network/client/Tls12Enforcement.kt
+++ b/network/src/main/java/uk/gov/android/network/client/Tls12Enforcement.kt
@@ -43,13 +43,9 @@ internal fun AndroidEngineConfig.configureSslManagerMinTls12(
 ) {
     sslManager = { connection ->
         val sslContext = createTls12SSLContext()
-        if (trustManager != null) {
-            sslContext.init(null, arrayOf(trustManager), null)
-        }
+        trustManager?.let { sslContext.init(null, arrayOf(it), null) }
         connection.sslSocketFactory = Tls12SocketFactory(sslContext.socketFactory)
-        if (hostnameVerifier != null) {
-            connection.hostnameVerifier = hostnameVerifier
-        }
+        hostnameVerifier?.let { connection.hostnameVerifier = it }
     }
 }
 

--- a/network/src/main/java/uk/gov/android/network/client/Tls12Enforcement.kt
+++ b/network/src/main/java/uk/gov/android/network/client/Tls12Enforcement.kt
@@ -1,0 +1,61 @@
+package uk.gov.android.network.client
+
+import java.net.Socket
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLSocket
+import javax.net.ssl.SSLSocketFactory
+
+private val TLS_12_AND_ABOVE = arrayOf("TLSv1.2", "TLSv1.3")
+
+internal fun createTls12SSLContext(): SSLContext =
+    SSLContext.getInstance("TLSv1.2").apply {
+        init(null, null, null)
+    }
+
+internal class Tls12SocketFactory(
+    private val delegate: SSLSocketFactory,
+) : SSLSocketFactory() {
+    override fun getDefaultCipherSuites(): Array<String> = delegate.defaultCipherSuites
+
+    override fun getSupportedCipherSuites(): Array<String> = delegate.supportedCipherSuites
+
+    override fun createSocket(): Socket = delegate.createSocket().enforceTls12()
+
+    override fun createSocket(
+        s: Socket?,
+        host: String?,
+        port: Int,
+        autoClose: Boolean,
+    ): Socket = delegate.createSocket(s, host, port, autoClose).enforceTls12()
+
+    override fun createSocket(
+        host: String?,
+        port: Int,
+    ): Socket = delegate.createSocket(host, port).enforceTls12()
+
+    override fun createSocket(
+        host: String?,
+        port: Int,
+        localHost: java.net.InetAddress?,
+        localPort: Int,
+    ): Socket = delegate.createSocket(host, port, localHost, localPort).enforceTls12()
+
+    override fun createSocket(
+        host: java.net.InetAddress?,
+        port: Int,
+    ): Socket = delegate.createSocket(host, port).enforceTls12()
+
+    override fun createSocket(
+        address: java.net.InetAddress?,
+        port: Int,
+        localAddress: java.net.InetAddress?,
+        localPort: Int,
+    ): Socket = delegate.createSocket(address, port, localAddress, localPort).enforceTls12()
+
+    private fun Socket.enforceTls12(): Socket =
+        apply {
+            if (this is SSLSocket) {
+                enabledProtocols = supportedProtocols.filter { it in TLS_12_AND_ABOVE }.toTypedArray()
+            }
+        }
+}

--- a/network/src/main/java/uk/gov/android/network/client/Tls12Enforcement.kt
+++ b/network/src/main/java/uk/gov/android/network/client/Tls12Enforcement.kt
@@ -54,8 +54,15 @@ internal class Tls12SocketFactory(
 
     private fun Socket.enforceTls12(): Socket =
         apply {
-            if (this is SSLSocket) {
-                enabledProtocols = supportedProtocols.filter { it in TLS_12_AND_ABOVE }.toTypedArray()
+            if (this !is SSLSocket) {
+                throw SslRequiredException(
+                    "Only SSL connections are permitted. Received ${this::class.simpleName}.",
+                )
             }
+            enabledProtocols = supportedProtocols.filter { it in TLS_12_AND_ABOVE }.toTypedArray()
         }
 }
+
+internal class SslRequiredException(
+    message: String,
+) : SecurityException(message)

--- a/network/src/main/java/uk/gov/android/network/client/Tls12Enforcement.kt
+++ b/network/src/main/java/uk/gov/android/network/client/Tls12Enforcement.kt
@@ -1,6 +1,7 @@
 package uk.gov.android.network.client
 
 import io.ktor.client.engine.android.AndroidEngineConfig
+import java.net.InetAddress
 import java.net.Socket
 import javax.net.ssl.HostnameVerifier
 import javax.net.ssl.SSLContext
@@ -83,19 +84,19 @@ internal class Tls12SocketFactory(
     override fun createSocket(
         host: String?,
         port: Int,
-        localHost: java.net.InetAddress?,
+        localHost: InetAddress?,
         localPort: Int,
     ): Socket = delegate.createSocket(host, port, localHost, localPort).enforceTls12()
 
     override fun createSocket(
-        host: java.net.InetAddress?,
+        host: InetAddress?,
         port: Int,
     ): Socket = delegate.createSocket(host, port).enforceTls12()
 
     override fun createSocket(
-        address: java.net.InetAddress?,
+        address: InetAddress?,
         port: Int,
-        localAddress: java.net.InetAddress?,
+        localAddress: InetAddress?,
         localPort: Int,
     ): Socket = delegate.createSocket(address, port, localAddress, localPort).enforceTls12()
 

--- a/network/src/test/java/uk/gov/android/network/client/Tls12EnforcementTest.kt
+++ b/network/src/test/java/uk/gov/android/network/client/Tls12EnforcementTest.kt
@@ -6,11 +6,14 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import uk.gov.android.network.log.KtorLogger
 import uk.gov.android.network.useragent.UserAgentGeneratorStub
 import java.net.InetAddress
 import java.net.ServerSocket
+import java.net.Socket
 import javax.net.ssl.SSLSocket
+import javax.net.ssl.SSLSocketFactory
 
 class Tls12EnforcementTest {
     private val sslContext = createTls12SSLContext()
@@ -131,5 +134,52 @@ class Tls12EnforcementTest {
         assertTrue(enabledProtocols.contains("TLSv1.2") || enabledProtocols.contains("TLSv1.3"))
         assertFalse(enabledProtocols.contains("TLSv1"))
         assertFalse(enabledProtocols.contains("TLSv1.1"))
+    }
+
+    @Test
+    fun `Tls12SocketFactory throws SslRequiredException for non-SSL socket`() {
+        val plainSocketFactory =
+            object : SSLSocketFactory() {
+                override fun getDefaultCipherSuites() = emptyArray<String>()
+
+                override fun getSupportedCipherSuites() = emptyArray<String>()
+
+                override fun createSocket() = Socket()
+
+                override fun createSocket(
+                    s: Socket?,
+                    host: String?,
+                    port: Int,
+                    autoClose: Boolean,
+                ) = Socket()
+
+                override fun createSocket(
+                    host: String?,
+                    port: Int,
+                ) = Socket()
+
+                override fun createSocket(
+                    host: String?,
+                    port: Int,
+                    localHost: InetAddress?,
+                    localPort: Int,
+                ) = Socket()
+
+                override fun createSocket(
+                    host: InetAddress?,
+                    port: Int,
+                ) = Socket()
+
+                override fun createSocket(
+                    address: InetAddress?,
+                    port: Int,
+                    localAddress: InetAddress?,
+                    localPort: Int,
+                ) = Socket()
+            }
+        val factory = Tls12SocketFactory(plainSocketFactory)
+        assertThrows<SslRequiredException> {
+            factory.createSocket()
+        }
     }
 }

--- a/network/src/test/java/uk/gov/android/network/client/Tls12EnforcementTest.kt
+++ b/network/src/test/java/uk/gov/android/network/client/Tls12EnforcementTest.kt
@@ -1,0 +1,135 @@
+package uk.gov.android.network.client
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import uk.gov.android.network.log.KtorLogger
+import uk.gov.android.network.useragent.UserAgentGeneratorStub
+import java.net.InetAddress
+import java.net.ServerSocket
+import javax.net.ssl.SSLSocket
+
+class Tls12EnforcementTest {
+    private val sslContext = createTls12SSLContext()
+    private val socketFactory = Tls12SocketFactory(sslContext.socketFactory)
+
+    @Test
+    fun `createTls12SSLContext returns a valid SSLContext`() {
+        assertNotNull(sslContext)
+        assertNotNull(sslContext.socketFactory)
+    }
+
+    @Test
+    fun `createSocket no-arg only enables TLS 1_2 or above`() {
+        val socket = socketFactory.createSocket() as SSLSocket
+        assertOnlyTls12AndAbove(socket)
+        socket.close()
+    }
+
+    @Test
+    fun `createSocket with host and port only enables TLS 1_2 or above`() {
+        val server = ServerSocket(0)
+        val port = server.localPort
+        val socket = socketFactory.createSocket("localhost", port) as SSLSocket
+        assertOnlyTls12AndAbove(socket)
+        socket.close()
+        server.close()
+    }
+
+    @Test
+    fun `createSocket with host port localAddr localPort only enables TLS 1_2 or above`() {
+        val server = ServerSocket(0)
+        val port = server.localPort
+        val socket =
+            socketFactory.createSocket(
+                "localhost",
+                port,
+                InetAddress.getLoopbackAddress(),
+                0,
+            ) as SSLSocket
+        assertOnlyTls12AndAbove(socket)
+        socket.close()
+        server.close()
+    }
+
+    @Test
+    fun `createSocket with InetAddress and port only enables TLS 1_2 or above`() {
+        val server = ServerSocket(0)
+        val port = server.localPort
+        val socket =
+            socketFactory.createSocket(
+                InetAddress.getLoopbackAddress(),
+                port,
+            ) as SSLSocket
+        assertOnlyTls12AndAbove(socket)
+        socket.close()
+        server.close()
+    }
+
+    @Test
+    fun `createSocket with InetAddress port localAddr localPort only enables TLS 1_2 or above`() {
+        val server = ServerSocket(0)
+        val port = server.localPort
+        val socket =
+            socketFactory.createSocket(
+                InetAddress.getLoopbackAddress(),
+                port,
+                InetAddress.getLoopbackAddress(),
+                0,
+            ) as SSLSocket
+        assertOnlyTls12AndAbove(socket)
+        socket.close()
+        server.close()
+    }
+
+    @Test
+    fun `createSocket with existing socket only enables TLS 1_2 or above`() {
+        val server = ServerSocket(0)
+        val port = server.localPort
+        val rawSocket = java.net.Socket("localhost", port)
+        val socket =
+            socketFactory.createSocket(
+                rawSocket,
+                "localhost",
+                port,
+                true,
+            ) as SSLSocket
+        assertOnlyTls12AndAbove(socket)
+        socket.close()
+        server.close()
+    }
+
+    @Test
+    fun `getDefaultCipherSuites delegates to wrapped factory`() {
+        val expected = sslContext.socketFactory.defaultCipherSuites
+        assertArrayEquals(expected, socketFactory.defaultCipherSuites)
+    }
+
+    @Test
+    fun `getSupportedCipherSuites delegates to wrapped factory`() {
+        val expected = sslContext.socketFactory.supportedCipherSuites
+        assertArrayEquals(expected, socketFactory.supportedCipherSuites)
+    }
+
+    @Test
+    fun `KtorHttpClient production constructor configures TLS correctly`() =
+        runTest {
+            // This exercises the secondary constructor path including the sslManager lambda
+            val client =
+                KtorHttpClient(
+                    userAgentGenerator = UserAgentGeneratorStub("test-agent"),
+                    logger = KtorLogger.noOp,
+                )
+            assertNotNull(client)
+        }
+
+    private fun assertOnlyTls12AndAbove(socket: SSLSocket) {
+        val enabledProtocols = socket.enabledProtocols.toList()
+        assertTrue(enabledProtocols.contains("TLSv1.2") || enabledProtocols.contains("TLSv1.3"))
+        assertFalse(enabledProtocols.contains("TLSv1"))
+        assertFalse(enabledProtocols.contains("TLSv1.1"))
+    }
+}


### PR DESCRIPTION
## Summary

Configures the Ktor Android engine with a custom `SSLSocketFactory` (`Tls12SocketFactory`) that only enables TLS 1.2 and TLS 1.3 protocols. This prevents connections to servers that only support TLS 1.0 or 1.1, regardless of the Android OS version.

## Why

Android 15 (API 35) blocks TLS 1.0/1.1 at the platform level for apps targeting API 35, but this restriction is only enforced on devices running Android 15+. Devices running Android 10–14 would still permit TLS 1.1 connections. This change enforces the restriction at the application layer so it applies uniformly across all supported API levels.

## Changes

- `Tls12Enforcement.kt` — new file with `createTls12SSLContext()` and `Tls12SocketFactory` that filters enabled protocols to TLS 1.2+
- `KtorHttpClient.kt` — secondary constructor now passes `sslManager` config to `Android.create()`
- `Tls12EnforcementTest.kt` — unit test verifying the socket factory strips TLS 1.0/1.1

## Testing

- All existing unit tests pass
- New unit test verifies protocol filtering