### PR TITLE
fix: DCMAW-21569 ApiResponse test assertions not available in published test fixtures

### DIFF
--- a/network/src/test/java/uk/gov/android/network/service/DefaultNetworkServiceTest.kt
+++ b/network/src/test/java/uk/gov/android/network/service/DefaultNetworkServiceTest.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Test
 import uk.gov.android.network.api.v2.ApiRequest
 import uk.gov.android.network.api.v2.ApiResponse
-import uk.gov.android.network.api.v2.expectFailure
+import uk.gov.android.network.api.v2.ApiResponseAssertions.expectFailure
 import uk.gov.android.network.attestation.TestClientAttestationProvider
 import uk.gov.android.network.attestation.clientAttestationFailure
 import uk.gov.android.network.auth.TestAuthenticationProvider

--- a/network/src/testFixtures/java/uk/gov/android/network/api/v2/ApiResponseAssertions.kt
+++ b/network/src/testFixtures/java/uk/gov/android/network/api/v2/ApiResponseAssertions.kt
@@ -2,9 +2,14 @@ package uk.gov.android.network.api.v2
 
 import org.junit.jupiter.api.Assertions.assertInstanceOf
 
-fun ApiResponse<*, *>.expectFailure(): ApiResponse.Failure<*> = assertInstanceOf(ApiResponse.Failure::class.java, this)
+object ApiResponseAssertions {
+    fun ApiResponse<*, *>.expectFailure(): ApiResponse.Failure<*> = assertInstanceOf(
+    ApiResponse.Failure::class.java,
+    this,
+    )
 
-fun <T> ApiResponse<T, *>.expectSuccess(): ApiResponse.Success<T> {
-    assertInstanceOf(ApiResponse.Success::class.java, this)
-    return this as ApiResponse.Success<T>
+    fun <T> ApiResponse<T, *>.expectSuccess(): ApiResponse.Success<T> {
+        assertInstanceOf(ApiResponse.Success::class.java, this)
+        return this as ApiResponse.Success<T>
+    }
 }


### PR DESCRIPTION
## Context

Extension functions don't seem to be available in test fixtures after they are published. I'm not sure the root cause of this problem. For now I've added the functions to an object which fixes the problem.

Enables testing for DCMAW-20189

## Evidence of the change

Tested locally using `publishToMavenLocal`.

[//]: # (Screenshots / uploaded videos go here)

## Checklist

### Before creating the pull request

- [ ] Commit messages that conform to conventional commit messages.
- [ ] Tests pass locally.
- [ ] Pull request has a clear title with a short description about the feature or update.
- [ ] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [ ] Complete all Acceptance Criteria within Jira ticket.
- [ ] Self-review code.
- [ ] Complete automated Testing:
  * [ ] Unit Tests.
  * [ ] Integration Tests.
  * [ ] Instrumentation / Emulator Tests.
- [ ] Handle PR comments.

### Before merging the pull request

- [ ] For **Defect**, **Tech Story** and **Story** tickets: Make sure that QA has reviewed (by checking they have the correct links to the correct JIRA tickets, the correct amount of details in the PR description to match the JIRA ticket, screenshot/video evidence attached when necessary) and commented QA approval.
- [ ] For **Tech Debt**, **Task** and **Spike** tickets (dev-only): Make sure that developer has reviewed (by checking they have the correct links to the correct JIRA tickets, the correct amount of details in the PR description to match the JIRA ticket, screenshot/video evidence attached when necessary) and commented Dev QA approval.
- [ ] [Sonar cloud report] passes inspections for your PR.
- [ ] Resolve all comments.

[Sonar cloud report]: https://sonarcloud.io/project/overview?id=mobile-android-networking
