### PR TITLE
feat: DCMAW-21605 Expose body of API failures from NetworkService

### DIFF
--- a/network/src/main/java/uk/gov/android/network/api/v2/ApiResponse.kt
+++ b/network/src/main/java/uk/gov/android/network/api/v2/ApiResponse.kt
@@ -4,7 +4,7 @@ package uk.gov.android.network.api.v2
  * The result of an [ApiRequest]
  */
 @Deprecated(
-    "Migrate to v3",
+    "Migrate to v3. To be removed on 23rd September 2026 (DCMAW-21647)",
     replaceWith = ReplaceWith(
         "ApiResponse",
         "uk.gov.android.network.api.v3.ApiResponse"

--- a/network/src/main/java/uk/gov/android/network/api/v2/ApiResponse.kt
+++ b/network/src/main/java/uk/gov/android/network/api/v2/ApiResponse.kt
@@ -3,6 +3,13 @@ package uk.gov.android.network.api.v2
 /**
  * The result of an [ApiRequest]
  */
+@Deprecated(
+    "Migrate to v3",
+    replaceWith = ReplaceWith(
+        "ApiResponse",
+        "uk.gov.android.network.api.v3.ApiResponse"
+    )
+)
 sealed interface ApiResponse<out T, out E : Exception> {
     /**
      * @property response the response body

--- a/network/src/main/java/uk/gov/android/network/api/v3/ApiResponse.kt
+++ b/network/src/main/java/uk/gov/android/network/api/v3/ApiResponse.kt
@@ -1,0 +1,36 @@
+package uk.gov.android.network.api.v3
+
+import uk.gov.android.network.api.v2.ApiRequest
+
+/**
+ * The result of an [ApiRequest]
+ *
+ * @param T the success response body type
+ * @param F the failure response body type
+ * @param E the exception type
+ */
+sealed interface ApiResponse<out T, out F, out E : Exception> {
+    /**
+     * @property status the HTTP status code
+     * @property body the response body
+     * @param T the success response body type
+     */
+    data class Success<T>(
+        val status: Int,
+        val body: T,
+    ) : ApiResponse<T, Nothing, Nothing>
+
+    /**
+     * @property error the cause of the failure
+     * @property status the HTTP status code, or null if no response was received (e.g. transport error)
+     * @property body the response body, or null if no response was received, or it was unusable
+     *
+     * @param F the failure response body type
+     * @param E the exception type
+     */
+    data class Failure<F, E : Exception>(
+        val error: E,
+        val status: Int? = null,
+        val body: F? = null,
+    ) : ApiResponse<Nothing, F, E>
+}

--- a/network/src/main/java/uk/gov/android/network/service/DefaultNetworkService.kt
+++ b/network/src/main/java/uk/gov/android/network/service/DefaultNetworkService.kt
@@ -22,7 +22,7 @@ import uk.gov.android.network.util.ExcludeFromJacocoGeneratedReport
  * @sample defaultNetworkServiceSample
  */
 @Deprecated(
-    "Migrate to v2",
+    "Migrate to v2. To be removed on 23rd September 2026 (DCMAW-21647)",
     replaceWith = ReplaceWith(
         "uk.gov.android.network.service.v2.DefaultNetworkService",
     )

--- a/network/src/main/java/uk/gov/android/network/service/DefaultNetworkService.kt
+++ b/network/src/main/java/uk/gov/android/network/service/DefaultNetworkService.kt
@@ -28,6 +28,12 @@ import uk.gov.android.network.util.NetworkingResult
  *
  * @sample defaultNetworkServiceSample
  */
+@Deprecated(
+    "Migrate to v2",
+    replaceWith = ReplaceWith(
+        "uk.gov.android.network.service.v2.DefaultNetworkService",
+    )
+)
 class DefaultNetworkService(
     private val httpClient: GenericHttpClient,
 ) : NetworkService {

--- a/network/src/main/java/uk/gov/android/network/service/DefaultNetworkService.kt
+++ b/network/src/main/java/uk/gov/android/network/service/DefaultNetworkService.kt
@@ -1,23 +1,16 @@
 package uk.gov.android.network.service
 
-import kotlinx.io.IOException
-import kotlinx.serialization.SerializationException
 import uk.gov.android.network.api.v2.ApiRequest
-import uk.gov.android.network.api.v2.ApiResponse
-import uk.gov.android.network.api.v2.withHeaders
+import uk.gov.android.network.api.v2.ApiResponse as ApiResponseV2
+import uk.gov.android.network.api.v3.ApiResponse
 import uk.gov.android.network.attestation.ClientAttestationProvider
 import uk.gov.android.network.auth.AuthenticationProvider
-import uk.gov.android.network.client.config.RequestConfig
 import uk.gov.android.network.client.config.RequestConfigBuilder
-import uk.gov.android.network.client.headers.AttestationHeaderReader
-import uk.gov.android.network.client.headers.AuthorisationHeaderReader
-import uk.gov.android.network.client.headers.RefreshDPoPHeaderReader
 import uk.gov.android.network.client.v2.GenericHttpClient
-import uk.gov.android.network.client.v2.GenericResponseException
+import uk.gov.android.network.service.v2.DefaultNetworkService as DefaultNetworkServiceV2
+import uk.gov.android.network.service.v2.NetworkService as NetworkServiceV2
 import uk.gov.android.network.dpop.DPoPProvider
-import uk.gov.android.network.http.Header
 import uk.gov.android.network.util.ExcludeFromJacocoGeneratedReport
-import uk.gov.android.network.util.NetworkingResult
 
 /**
  * Default [NetworkService] implementation.
@@ -35,126 +28,34 @@ import uk.gov.android.network.util.NetworkingResult
     )
 )
 class DefaultNetworkService(
-    private val httpClient: GenericHttpClient,
+    private val delegate: DefaultNetworkServiceV2
 ) : NetworkService {
-    private var attestationHeaderReader = AttestationHeaderReader(null)
-    private var authorisationHeaderReader = AuthorisationHeaderReader(null)
-    private var refreshDPoPHeaderReader = RefreshDPoPHeaderReader(null)
+    constructor(
+        httpClient: GenericHttpClient
+    ) : this(
+        DefaultNetworkServiceV2(httpClient)
+    )
 
     override suspend fun makeRequest(
         apiRequest: ApiRequest,
         configure: RequestConfigBuilder.() -> Unit,
-    ): ApiResponse<String, NetworkingException> {
-        val config = RequestConfigBuilder().apply { configure() }.build()
+    ): ApiResponseV2<String, NetworkingException> =
+        delegate.makeRequest(apiRequest, configure)
+            .toApiResponseV2()
 
-        val extraHeaders =
-            when (val result = buildExtraHeaders(config)) {
-                is NetworkingResult.Failure -> {
-                    return ApiResponse.Failure(result.exception)
-                }
-                is NetworkingResult.Success -> result.value
-            }
+    fun setAuthenticationProvider(authenticationProvider: AuthenticationProvider?) =
+        delegate.setAuthenticationProvider(authenticationProvider)
 
-        val apiRequest = apiRequest.withHeaders(extraHeaders)
+    fun setClientAttestationProvider(clientAttestationProvider: ClientAttestationProvider?) =
+        delegate.setClientAttestationProvider(clientAttestationProvider)
 
-        val response =
-            try {
-                httpClient.request(apiRequest)
-            } catch (exception: SerializationException) {
-                return exception.toApiRequestFailure()
-            } catch (exception: GenericResponseException) {
-                // Unsuccessful (3XX, 4XX, 5XX) response
-                return exception.toApiResponseFailure()
-            } catch (exception: IOException) {
-                return exception.toTransportFailure()
-            }
+    fun setDPoPProvider(dpopProvider: DPoPProvider?) =
+        delegate.setDPoPProvider(dpopProvider)
 
-        // Successful (1XX or 2XX) response
-        return ApiResponse.Success(
-            response = response.body,
-            status = response.status,
-        )
+    private fun NetworkServiceV2.RawApiResponse.toApiResponseV2() = when (this) {
+        is ApiResponse.Failure<String, NetworkingException> -> ApiResponseV2.Failure(error, status)
+        is ApiResponse.Success<String> -> ApiResponseV2.Success(body, status)
     }
-
-    fun setAuthenticationProvider(authenticationProvider: AuthenticationProvider?) {
-        authorisationHeaderReader = AuthorisationHeaderReader(authenticationProvider)
-    }
-
-    fun setClientAttestationProvider(clientAttestationProvider: ClientAttestationProvider?) {
-        attestationHeaderReader = AttestationHeaderReader(clientAttestationProvider)
-    }
-
-    fun setDPoPProvider(dpopProvider: DPoPProvider?) {
-        refreshDPoPHeaderReader = RefreshDPoPHeaderReader(dpopProvider)
-    }
-
-    private suspend fun buildExtraHeaders(config: RequestConfig): NetworkingResult<List<Header>> {
-        val attestationHeaders =
-            if (config.attestation) {
-                when (val result = attestationHeaderReader.getHeaders()) {
-                    is NetworkingResult.Failure -> return NetworkingResult.Failure(result.exception)
-                    is NetworkingResult.Success -> result.value
-                }
-            } else {
-                emptyList()
-            }
-
-        val authHeader =
-            if (config.authentication != null) {
-                when (
-                    val result = authorisationHeaderReader.getHeader(config.authentication)
-                ) {
-                    is NetworkingResult.Failure -> return NetworkingResult.Failure(result.exception)
-                    is NetworkingResult.Success -> result.value
-                }
-            } else {
-                null
-            }
-
-        val refreshDPoPHeader =
-            if (config.refreshDPoP) {
-                when (val result = refreshDPoPHeaderReader.getHeader()) {
-                    is NetworkingResult.Failure -> return NetworkingResult.Failure(result.exception)
-                    is NetworkingResult.Success -> result.value
-                }
-            } else {
-                null
-            }
-
-        return NetworkingResult.Success(
-            attestationHeaders +
-                listOfNotNull(
-                    authHeader,
-                    refreshDPoPHeader,
-                ),
-        )
-    }
-
-    private fun Exception.toTransportFailure(): ApiResponse.Failure<TransportException> =
-        ApiResponse.Failure(
-            TransportException(this),
-            null,
-        )
-
-    private fun GenericResponseException.toApiResponseFailure(): ApiResponse.Failure<ApiResponseException> =
-        ApiResponse.Failure(
-            status = response.status,
-            error =
-                ApiResponseException(
-                    "API responded with ${response.status}",
-                    this,
-                ),
-        )
-
-    private fun SerializationException.toApiRequestFailure(): ApiResponse.Failure<ApiRequestException> =
-        ApiResponse.Failure(
-            status = null,
-            error =
-                ApiRequestException(
-                    "Serialization failed",
-                    this,
-                ),
-        )
 }
 
 @ExcludeFromJacocoGeneratedReport

--- a/network/src/main/java/uk/gov/android/network/service/NetworkService.kt
+++ b/network/src/main/java/uk/gov/android/network/service/NetworkService.kt
@@ -17,6 +17,12 @@ import uk.gov.android.network.util.ExcludeFromJacocoGeneratedReport
  *
  * @see [RequestConfigBuilder]
  */
+@Deprecated(
+    "Migrate to v2",
+    replaceWith = ReplaceWith(
+        "uk.gov.android.network.service.v2.NetworkService",
+    )
+)
 interface NetworkService {
     /**
      * Make an HTTP request and return the raw response body.

--- a/network/src/main/java/uk/gov/android/network/service/NetworkService.kt
+++ b/network/src/main/java/uk/gov/android/network/service/NetworkService.kt
@@ -18,7 +18,7 @@ import uk.gov.android.network.util.ExcludeFromJacocoGeneratedReport
  * @see [RequestConfigBuilder]
  */
 @Deprecated(
-    "Migrate to v2",
+    "Migrate to v2. To be removed on 23rd September 2026 (DCMAW-21647)",
     replaceWith = ReplaceWith(
         "uk.gov.android.network.service.v2.NetworkService",
     )

--- a/network/src/main/java/uk/gov/android/network/service/NetworkServiceJsonExt.kt
+++ b/network/src/main/java/uk/gov/android/network/service/NetworkServiceJsonExt.kt
@@ -9,6 +9,13 @@ import uk.gov.android.network.client.config.RequestConfigBuilder
 import uk.gov.android.network.service.NetworkServiceJsonExt.makeRequest
 import uk.gov.android.network.util.ExcludeFromJacocoGeneratedReport
 
+@Deprecated(
+    "Migrate to v2",
+    replaceWith = ReplaceWith(
+        "NetworkServiceTypedSuccessExt",
+        "uk.gov.android.network.service.v2.NetworkServiceTypedSuccessExt"
+    )
+)
 object NetworkServiceJsonExt {
     /**
      * Default JSON decoder for decoding network responses
@@ -27,6 +34,13 @@ object NetworkServiceJsonExt {
 
      * @return ApiResponse<T, NetworkingException> The API response or error.
      */
+    @Deprecated(
+        "Migrate to NetworkServiceTypedSuccessExt.makeRequest",
+        replaceWith = ReplaceWith(
+            "makeRequest<T>(apiRequest, configure)",
+            "uk.gov.android.network.service.v2.NetworkServiceTypedSuccessExt.makeRequest"
+        )
+    )
     suspend inline fun <reified T> NetworkService.makeRequest(
         apiRequest: ApiRequest,
         json: Json = jsonDecoder,

--- a/network/src/main/java/uk/gov/android/network/service/NetworkServiceJsonExt.kt
+++ b/network/src/main/java/uk/gov/android/network/service/NetworkServiceJsonExt.kt
@@ -10,7 +10,7 @@ import uk.gov.android.network.service.NetworkServiceJsonExt.makeRequest
 import uk.gov.android.network.util.ExcludeFromJacocoGeneratedReport
 
 @Deprecated(
-    "Migrate to v2",
+    "Migrate to v2. To be removed on 23rd September 2026 (DCMAW-21647)",
     replaceWith = ReplaceWith(
         "NetworkServiceTypedSuccessExt",
         "uk.gov.android.network.service.v2.NetworkServiceTypedSuccessExt"
@@ -35,7 +35,8 @@ object NetworkServiceJsonExt {
      * @return ApiResponse<T, NetworkingException> The API response or error.
      */
     @Deprecated(
-        "Migrate to NetworkServiceTypedSuccessExt.makeRequest",
+        "Migrate to NetworkServiceTypedSuccessExt.makeRequest. " +
+                "To be removed on 23rd September 2026 (DCMAW-21647)",
         replaceWith = ReplaceWith(
             "makeRequest<T>(apiRequest, configure)",
             "uk.gov.android.network.service.v2.NetworkServiceTypedSuccessExt.makeRequest"

--- a/network/src/main/java/uk/gov/android/network/service/json/JsonDefaults.kt
+++ b/network/src/main/java/uk/gov/android/network/service/json/JsonDefaults.kt
@@ -1,0 +1,12 @@
+package uk.gov.android.network.service.json
+
+import kotlinx.serialization.json.Json
+
+object JsonDefaults {
+    /**
+     * Default JSON decoder for decoding network responses
+     */
+    val jsonDecoder = Json {
+        ignoreUnknownKeys = true
+    }
+}

--- a/network/src/main/java/uk/gov/android/network/service/v2/DefaultNetworkService.kt
+++ b/network/src/main/java/uk/gov/android/network/service/v2/DefaultNetworkService.kt
@@ -1,0 +1,183 @@
+package uk.gov.android.network.service.v2
+
+import kotlinx.io.IOException
+import kotlinx.serialization.SerializationException
+import uk.gov.android.network.api.v2.ApiRequest
+import uk.gov.android.network.api.v3.ApiResponse
+import uk.gov.android.network.api.v2.withHeaders
+import uk.gov.android.network.attestation.ClientAttestationProvider
+import uk.gov.android.network.auth.AuthenticationProvider
+import uk.gov.android.network.client.config.RequestConfig
+import uk.gov.android.network.client.config.RequestConfigBuilder
+import uk.gov.android.network.client.headers.AttestationHeaderReader
+import uk.gov.android.network.client.headers.AuthorisationHeaderReader
+import uk.gov.android.network.client.headers.RefreshDPoPHeaderReader
+import uk.gov.android.network.client.v2.GenericHttpClient
+import uk.gov.android.network.client.v2.GenericResponseException
+import uk.gov.android.network.dpop.DPoPProvider
+import uk.gov.android.network.http.Header
+import uk.gov.android.network.service.ApiRequestException
+import uk.gov.android.network.service.ApiResponseException
+import uk.gov.android.network.service.TransportException
+import uk.gov.android.network.util.ExcludeFromJacocoGeneratedReport
+import uk.gov.android.network.util.NetworkingResult
+
+/**
+ * Default [NetworkService] implementation.
+ *
+ * To enable authentication, provide an [AuthenticationProvider] using [setAuthenticationProvider].
+ * To enable client attestation headers, provide a [ClientAttestationProvider] using [setClientAttestationProvider].
+ * To enable demonstrating proof-of-possession (DPoP) headers, provide a [DPoPProvider] using [setDPoPProvider].
+ *
+ * @sample defaultNetworkServiceSample
+ */
+class DefaultNetworkService(
+    private val httpClient: GenericHttpClient,
+) : NetworkService {
+    private var attestationHeaderReader = AttestationHeaderReader(null)
+    private var authorisationHeaderReader = AuthorisationHeaderReader(null)
+    private var refreshDPoPHeaderReader = RefreshDPoPHeaderReader(null)
+
+    override suspend fun makeRequest(
+        apiRequest: ApiRequest,
+        configure: RequestConfigBuilder.() -> Unit,
+    ): NetworkService.RawApiResponse {
+        val config = RequestConfigBuilder().apply { configure() }.build()
+
+        val extraHeaders =
+            when (val result = buildExtraHeaders(config)) {
+                is NetworkingResult.Failure -> {
+                    return ApiResponse.Failure(result.exception)
+                }
+                is NetworkingResult.Success -> result.value
+            }
+
+        val apiRequest = apiRequest.withHeaders(extraHeaders)
+
+        val response =
+            try {
+                httpClient.request(apiRequest)
+            } catch (exception: SerializationException) {
+                return exception.toApiRequestFailure()
+            } catch (exception: GenericResponseException) {
+                // Unsuccessful (3XX, 4XX, 5XX) response
+                return exception.toApiResponseFailure()
+            } catch (exception: IOException) {
+                return exception.toTransportFailure()
+            }
+
+        // Successful (1XX or 2XX) response
+        return ApiResponse.Success(
+            body = response.body,
+            status = response.status,
+        )
+    }
+
+    fun setAuthenticationProvider(authenticationProvider: AuthenticationProvider?) {
+        authorisationHeaderReader = AuthorisationHeaderReader(authenticationProvider)
+    }
+
+    fun setClientAttestationProvider(clientAttestationProvider: ClientAttestationProvider?) {
+        attestationHeaderReader = AttestationHeaderReader(clientAttestationProvider)
+    }
+
+    fun setDPoPProvider(dpopProvider: DPoPProvider?) {
+        refreshDPoPHeaderReader = RefreshDPoPHeaderReader(dpopProvider)
+    }
+
+    private suspend fun buildExtraHeaders(config: RequestConfig): NetworkingResult<List<Header>> {
+        val attestationHeaders =
+            if (config.attestation) {
+                when (val result = attestationHeaderReader.getHeaders()) {
+                    is NetworkingResult.Failure -> return NetworkingResult.Failure(result.exception)
+                    is NetworkingResult.Success -> result.value
+                }
+            } else {
+                emptyList()
+            }
+
+        val authHeader =
+            if (config.authentication != null) {
+                when (
+                    val result = authorisationHeaderReader.getHeader(config.authentication)
+                ) {
+                    is NetworkingResult.Failure -> return NetworkingResult.Failure(result.exception)
+                    is NetworkingResult.Success -> result.value
+                }
+            } else {
+                null
+            }
+
+        val refreshDPoPHeader =
+            if (config.refreshDPoP) {
+                when (val result = refreshDPoPHeaderReader.getHeader()) {
+                    is NetworkingResult.Failure -> return NetworkingResult.Failure(result.exception)
+                    is NetworkingResult.Success -> result.value
+                }
+            } else {
+                null
+            }
+
+        return NetworkingResult.Success(
+            attestationHeaders +
+                listOfNotNull(
+                    authHeader,
+                    refreshDPoPHeader,
+                ),
+        )
+    }
+
+    private fun Exception.toTransportFailure(): ApiResponse.Failure<String, TransportException> =
+        ApiResponse.Failure(
+            TransportException(this),
+            null,
+        )
+
+    private fun GenericResponseException.toApiResponseFailure(): ApiResponse.Failure<String, ApiResponseException> =
+        ApiResponse.Failure(
+            status = response.status,
+            body = response.body,
+            error =
+                ApiResponseException(
+                    "API responded with ${response.status}",
+                    this,
+                ),
+        )
+
+    private fun SerializationException.toApiRequestFailure(): ApiResponse.Failure<String, ApiRequestException> =
+        ApiResponse.Failure(
+            status = null,
+            body = null,
+            error =
+                ApiRequestException(
+                    "Serialization failed",
+                    this,
+                ),
+        )
+}
+
+@ExcludeFromJacocoGeneratedReport
+internal suspend fun defaultNetworkServiceSample(
+    apiRequest: ApiRequest,
+    httpClient: GenericHttpClient,
+    authenticationProvider: AuthenticationProvider,
+    clientAttestationProvider: ClientAttestationProvider,
+    dPoPProvider: DPoPProvider,
+) {
+    val networkService = DefaultNetworkService(httpClient)
+
+    // Set the authentication provider before making authenticated requests
+    networkService.setAuthenticationProvider(authenticationProvider)
+
+    // Set the client attestation provider before asking for client attestation headers
+    networkService.setClientAttestationProvider(clientAttestationProvider)
+
+    // Set the DPoP provider before asking for demonstrating proof-of-possession headers
+    networkService.setDPoPProvider(dPoPProvider)
+
+    networkService.makeRequest(apiRequest) {
+        withAuthentication("scope")
+        withAttestation = true
+        withRefreshDPoP = true
+    }
+}

--- a/network/src/main/java/uk/gov/android/network/service/v2/NetworkService.kt
+++ b/network/src/main/java/uk/gov/android/network/service/v2/NetworkService.kt
@@ -1,0 +1,84 @@
+package uk.gov.android.network.service.v2
+
+import uk.gov.android.network.api.v2.ApiRequest
+import uk.gov.android.network.api.v3.ApiResponse
+import uk.gov.android.network.client.config.RequestConfigBuilder
+import uk.gov.android.network.service.ApiRequestException
+import uk.gov.android.network.service.ApiResponseException
+import uk.gov.android.network.service.ConfigurationException
+import uk.gov.android.network.service.NetworkingException
+import uk.gov.android.network.service.ServiceException
+import uk.gov.android.network.service.TransportException
+import uk.gov.android.network.util.ExcludeFromJacocoGeneratedReport
+
+/**
+ * [NetworkService] makes HTTP requests and returns success or failure.
+ *
+ * Supports appending authentication, attestation, and DPoP headers to requests.
+ *
+ * To parse JSON responses to a custom response type, use [NetworkServiceTypedSuccessExt.makeRequest].
+ *
+ * @sample networkServiceSample
+ * @sample networkServiceParseSuccessSample
+ * @sample networkServiceParseFailureSample
+ *
+ * @see [RequestConfigBuilder]
+ */
+interface NetworkService {
+
+    typealias RawApiResponse = ApiResponse<String, String, NetworkingException>
+
+    /**
+     * Make an HTTP request and return the raw response body.
+     *
+     * @sample networkServiceSample
+     *
+     * @param apiRequest The base API request
+     * @param configure Configure extra behaviour such as authentication, attestation and DPoP
+
+     * @return ApiResponse<String, String, NetworkingException> The API response or error.
+     *   Successful responses include the raw response body
+     */
+    suspend fun makeRequest(
+        apiRequest: ApiRequest,
+        configure: RequestConfigBuilder.() -> Unit = { },
+    ): RawApiResponse
+
+}
+
+@ExcludeFromJacocoGeneratedReport
+internal suspend fun networkServiceSample(networkService: NetworkService) {
+    val request =
+        ApiRequest.Get(
+            url = "https://example.gov.uk",
+            headers =
+                listOf(
+                    "x-example" to "example header",
+                ),
+        )
+
+    val response =
+        networkService.makeRequest(request) {
+            withAttestation = true
+            withAuthentication("scope")
+            withRefreshDPoP = true
+        }
+
+    when (response) {
+        is ApiResponse.Success -> {
+            // Parse the response
+        }
+        is ApiResponse.Failure -> {
+            when (response.error) {
+                is ApiRequestException,
+                is ApiResponseException,
+                is ConfigurationException,
+                is ServiceException,
+                is TransportException,
+                -> {
+                    // Handle any errors
+                }
+            }
+        }
+    }
+}

--- a/network/src/main/java/uk/gov/android/network/service/v2/NetworkServiceTypedFailureExt.kt
+++ b/network/src/main/java/uk/gov/android/network/service/v2/NetworkServiceTypedFailureExt.kt
@@ -1,0 +1,95 @@
+package uk.gov.android.network.service.v2
+
+import android.util.Log
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import uk.gov.android.network.api.v2.ApiRequest
+import uk.gov.android.network.api.v3.ApiResponse
+import uk.gov.android.network.client.config.RequestConfigBuilder
+import uk.gov.android.network.service.ApiResponseException
+import uk.gov.android.network.service.NetworkingException
+import uk.gov.android.network.service.json.JsonDefaults
+import uk.gov.android.network.service.v2.NetworkServiceTypedFailureExt.makeRequest
+import uk.gov.android.network.service.v2.NetworkServiceTypedSuccessExt.makeRequest
+import uk.gov.android.network.util.ExcludeFromJacocoGeneratedReport
+
+object NetworkServiceTypedFailureExt {
+    /**
+     * Make an HTTP request and parse the JSON response
+     *
+     * @sample networkServiceParseFailureSample
+     *
+     * @param T the success response body type
+     * @param F the failure response body type
+     * @param apiRequest The base API request
+     * @param json The JSON decoder to parse responses with
+     * @param configure Configure extra behaviour such as authentication, attestation and DPoP
+
+     * @return ApiResponse<T, F, NetworkingException> The API response or error.
+     */
+    suspend inline fun <reified T, reified F> NetworkService.makeRequest(
+        apiRequest: ApiRequest,
+        json: Json = JsonDefaults.jsonDecoder,
+        noinline configure: RequestConfigBuilder.() -> Unit = {},
+    ): ApiResponse<T, F, NetworkingException> {
+        val response = makeRequest<T>(apiRequest, json, configure)
+
+        val failure =
+            when (response) {
+                is ApiResponse.Success<T> -> return response
+                is ApiResponse.Failure<String, NetworkingException> -> response
+            }
+
+        val body = failure.body ?: return ApiResponse.Failure(
+            error = response.error,
+            status = response.status,
+            body = null,
+        )
+
+        val parsed =
+            try {
+                json.decodeFromString<F>(body)
+            } catch (e: IllegalArgumentException) {
+                return ApiResponse.Failure(
+                    error = ApiResponseException("Failed to parse response body as ${F::class}", e),
+                    status = failure.status,
+                    body = null,
+                )
+            }
+
+        return ApiResponse.Failure(
+            error = response.error,
+            body = parsed,
+            status = response.status,
+        )
+    }
+}
+
+@ExcludeFromJacocoGeneratedReport
+internal suspend fun networkServiceParseFailureSample(
+    request: ApiRequest,
+    networkService: NetworkService,
+) {
+    @Serializable
+    @ExcludeFromJacocoGeneratedReport
+    data class CustomSuccess(
+        val subject: String,
+        val message: String,
+    )
+
+    @Serializable
+    @ExcludeFromJacocoGeneratedReport
+    data class CustomFailure(
+        val errorCode: String,
+    )
+    val response =
+        networkService.makeRequest<CustomSuccess, CustomFailure>(request)
+
+    when (response) {
+        is ApiResponse.Failure -> {
+            val errorCode = response.body?.errorCode
+            Log.d("demo", "errorCode: $errorCode")
+        }
+        else -> { }
+    }
+}

--- a/network/src/main/java/uk/gov/android/network/service/v2/NetworkServiceTypedSuccessExt.kt
+++ b/network/src/main/java/uk/gov/android/network/service/v2/NetworkServiceTypedSuccessExt.kt
@@ -24,7 +24,7 @@ object NetworkServiceTypedSuccessExt {
      * @param json The JSON decoder to parse responses with
      * @param configure Configure extra behaviour such as authentication, attestation and DPoP
 
-     * @return ApiResponse<T, NetworkingException> The API response or error.
+     * @return ApiResponse<T, String, NetworkingException> The API response or error.
      */
     suspend inline fun <reified T> NetworkService.makeRequest(
         apiRequest: ApiRequest,

--- a/network/src/main/java/uk/gov/android/network/service/v2/NetworkServiceTypedSuccessExt.kt
+++ b/network/src/main/java/uk/gov/android/network/service/v2/NetworkServiceTypedSuccessExt.kt
@@ -1,0 +1,86 @@
+package uk.gov.android.network.service.v2
+
+import android.util.Log
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import uk.gov.android.network.api.v2.ApiRequest
+import uk.gov.android.network.api.v3.ApiResponse
+import uk.gov.android.network.client.config.RequestConfigBuilder
+import uk.gov.android.network.service.ApiResponseException
+import uk.gov.android.network.service.NetworkingException
+import uk.gov.android.network.service.json.JsonDefaults
+import uk.gov.android.network.service.v2.NetworkServiceTypedSuccessExt.makeRequest
+import uk.gov.android.network.util.ExcludeFromJacocoGeneratedReport
+
+object NetworkServiceTypedSuccessExt {
+
+    /**
+     * Make an HTTP request and parse the JSON response
+     *
+     * @sample networkServiceParseSuccessSample
+     *
+     * @param T the success response body type
+     * @param apiRequest The base API request
+     * @param json The JSON decoder to parse responses with
+     * @param configure Configure extra behaviour such as authentication, attestation and DPoP
+
+     * @return ApiResponse<T, NetworkingException> The API response or error.
+     */
+    suspend inline fun <reified T> NetworkService.makeRequest(
+        apiRequest: ApiRequest,
+        json: Json = JsonDefaults.jsonDecoder,
+        noinline configure: RequestConfigBuilder.() -> Unit = {},
+    ): ApiResponse<T, String, NetworkingException> {
+        val response = makeRequest(apiRequest, configure)
+
+        val success =
+            when (response) {
+                is ApiResponse.Failure<String, *> -> return response
+                is ApiResponse.Success<String> -> response
+            }
+
+        val parsed =
+            try {
+                json.decodeFromString<T>(success.body)
+            } catch (e: IllegalArgumentException) {
+                return ApiResponse.Failure(
+                    error = ApiResponseException("Failed to parse response body as ${T::class}", e),
+                    status = success.status,
+                    // Don't include the response in the failure result.
+                    // Consumers may try to parse this response downstream and expect it to be a
+                    // different shape to a successful response body.
+                    body = null,
+                )
+            }
+
+        return ApiResponse.Success(
+            body = parsed,
+            status = response.status,
+        )
+    }
+}
+
+@ExcludeFromJacocoGeneratedReport
+internal suspend fun networkServiceParseSuccessSample(
+    request: ApiRequest,
+    networkService: NetworkService,
+) {
+    @Serializable
+    @ExcludeFromJacocoGeneratedReport
+    data class CustomResponse(
+        val subject: String,
+        val message: String,
+    )
+
+    val response =
+        networkService.makeRequest<CustomResponse>(request)
+
+    when (response) {
+        is ApiResponse.Success -> {
+            // The response is parsed as `CustomResponse`
+            val (subject, message) = response.body
+            Log.d("demo", "subject: $subject; message: $message")
+        }
+        else -> { }
+    }
+}

--- a/network/src/main/java/uk/gov/android/network/util/ExcludeFromJacocoGeneratedReport.kt
+++ b/network/src/main/java/uk/gov/android/network/util/ExcludeFromJacocoGeneratedReport.kt
@@ -1,5 +1,5 @@
 package uk.gov.android.network.util
 
 @Retention(AnnotationRetention.RUNTIME)
-@Target(AnnotationTarget.FUNCTION, AnnotationTarget.VALUE_PARAMETER)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.CLASS)
 internal annotation class ExcludeFromJacocoGeneratedReport

--- a/network/src/main/java/uk/gov/android/network/util/NetworkingResult.kt
+++ b/network/src/main/java/uk/gov/android/network/util/NetworkingResult.kt
@@ -1,5 +1,6 @@
 package uk.gov.android.network.util
 
+import uk.gov.android.network.api.v2.ApiResponse
 import uk.gov.android.network.service.NetworkingException
 
 internal sealed class NetworkingResult<T> {

--- a/network/src/test/java/uk/gov/android/network/service/v2/DefaultNetworkServiceTest.kt
+++ b/network/src/test/java/uk/gov/android/network/service/v2/DefaultNetworkServiceTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.android.network.service
+package uk.gov.android.network.service.v2
 
 import kotlinx.coroutines.test.runTest
 import kotlinx.io.IOException
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Test
 import uk.gov.android.network.api.v2.ApiRequest
-import uk.gov.android.network.api.v2.ApiResponse
-import uk.gov.android.network.api.v2.ApiResponseAssertions.expectFailure
+import uk.gov.android.network.api.v3.ApiResponse
+import uk.gov.android.network.api.v3.ApiResponseAssertions.expectFailure
 import uk.gov.android.network.attestation.TestClientAttestationProvider
 import uk.gov.android.network.attestation.clientAttestationFailure
 import uk.gov.android.network.auth.TestAuthenticationProvider
@@ -18,6 +18,10 @@ import uk.gov.android.network.client.v2.TestHttpResponse
 import uk.gov.android.network.client.v2.TestResponseException
 import uk.gov.android.network.dpop.TestDPoPProvider
 import uk.gov.android.network.dpop.dpopFailure
+import uk.gov.android.network.service.ApiRequestException
+import uk.gov.android.network.service.ApiResponseException
+import uk.gov.android.network.service.ServiceException
+import uk.gov.android.network.service.TransportException
 import kotlin.jvm.java
 
 class DefaultNetworkServiceTest {
@@ -29,17 +33,17 @@ class DefaultNetworkServiceTest {
     private val dpopProvider = TestDPoPProvider()
 
     @Test
-    fun `given client returns response, makeRequest returns success with body and status`() =
+    fun `given client returns success response, makeRequest returns success with body and status`() =
         runTest {
             httpClient.response = TestHttpResponse.success
 
             val result = networkService.makeRequest(request)
 
-            assertEquals(ApiResponse.Success("success", status = 200), result)
+            assertEquals(ApiResponse.Success(status = 200, body = "success"), result)
         }
 
     @Test
-    fun `given client throws ResponseExceptionWrapper, makeRequest returns API response failure`() =
+    fun `given client throws GenericResponseException, makeRequest returns API response failure`() =
         runTest {
             httpClient.exception = TestResponseException.internalServerError
 
@@ -48,6 +52,7 @@ class DefaultNetworkServiceTest {
             val failure = result.expectFailure()
             assertInstanceOf(ApiResponseException::class.java, failure.error)
             assertEquals(500, failure.status)
+            assertEquals("error", failure.body)
         }
 
     @Test

--- a/network/src/test/java/uk/gov/android/network/service/v2/NetworkServiceTypedFailureExtTest.kt
+++ b/network/src/test/java/uk/gov/android/network/service/v2/NetworkServiceTypedFailureExtTest.kt
@@ -1,0 +1,159 @@
+package uk.gov.android.network.service.v2
+
+import kotlinx.coroutines.test.runTest
+import kotlinx.io.IOException
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import uk.gov.android.network.api.v2.ApiRequest
+import uk.gov.android.network.api.v3.ApiResponseAssertions.expectFailure
+import uk.gov.android.network.api.v3.ApiResponseAssertions.expectSuccess
+import uk.gov.android.network.client.v2.GenericHttpResponse
+import uk.gov.android.network.client.v2.GenericResponseException
+import uk.gov.android.network.client.v2.StubHttpClient
+import uk.gov.android.network.service.ApiResponseException
+import uk.gov.android.network.service.TransportException
+import uk.gov.android.network.service.v2.NetworkServiceTypedFailureExt.makeRequest
+
+class NetworkServiceTypedFailureExtTest {
+    private val httpClient = StubHttpClient()
+    private val networkService = DefaultNetworkService(httpClient = httpClient)
+    private val request = ApiRequest.Get(url = "https://example.gov.uk")
+    private val failureStatus = 500
+
+    @Test
+    fun `given valid json response, makeRequest returns parsed success`() =
+        runTest {
+            httpClient.response = GenericHttpResponse(
+                status = 200,
+                body = """{"subject":"Test","message":"Hello"}""",
+            )
+
+            val result = networkService.makeRequest<SuccessData, FailureData>(request)
+
+            val success = result.expectSuccess()
+            assertEquals(SuccessData("Test", "Hello"), success.body)
+            assertEquals(200, success.status)
+        }
+
+    @Test
+    fun `given failure response with valid json, makeRequest returns parsed failure`() =
+        runTest {
+            givenFailureResponse()
+
+            val result = networkService.makeRequest<SuccessData, FailureData>(request)
+
+            val failure = result.expectFailure()
+            assertEquals(FailureData(123), failure.body)
+            assertEquals(failureStatus, failure.status)
+            assertInstanceOf(ApiResponseException::class.java, failure.error)
+        }
+
+    @Test
+    fun `given failure response with unparseable json, makeRequest returns failure with null response`() =
+        runTest {
+            givenFailureResponse("""{"unexpected":"structure"}""")
+
+            val result = networkService.makeRequest<SuccessData, FailureData>(request)
+
+            val failure = result.expectFailure()
+            assertNull(failure.body)
+            assertEquals(failureStatus, failure.status)
+            assertEquals(
+                "Failed to parse response body as class uk.gov.android.network.service.v2.FailureData",
+                failure.error.message,
+            )
+            assertInstanceOf(ApiResponseException::class.java, failure.error)
+        }
+
+    @Test
+    fun `given failure response with invalid json, makeRequest returns failure with null response`() =
+        runTest {
+            givenFailureResponse("not json at all")
+
+            val result = networkService.makeRequest<SuccessData, FailureData>(request)
+
+            val failure = result.expectFailure()
+            assertNull(failure.body)
+            assertEquals(failureStatus, failure.status)
+            assertEquals(
+                "Failed to parse response body as class uk.gov.android.network.service.v2.FailureData",
+                failure.error.message,
+            )
+            assertInstanceOf(ApiResponseException::class.java, failure.error)
+        }
+
+    @Test
+    fun `given transport failure, makeRequest returns failure with null response`() =
+        runTest {
+            httpClient.exception = IOException("connection failed")
+
+            val result = networkService.makeRequest<SuccessData, FailureData>(request)
+
+            val failure = result.expectFailure()
+            assertNull(failure.body)
+            assertNull(failure.status)
+            assertInstanceOf(TransportException::class.java, failure.error)
+        }
+
+    @Test
+    fun `given failure response with unknown key, makeRequest returns parsed failure`() =
+        runTest {
+            givenFailureResponse("""{"errorCode":123,"extra":"unknown"}""")
+
+            val result = networkService.makeRequest<SuccessData, FailureData>(request)
+
+            val failure = result.expectFailure()
+            assertEquals(FailureData(123), failure.body)
+            assertEquals(failureStatus, failure.status)
+        }
+
+    @Test
+    fun `when Json is provided, makeRequest uses the given implementation for failure parsing`() =
+        runTest {
+            val strictJson = Json { ignoreUnknownKeys = false }
+            givenFailureResponse("""{"errorCode":123,"extra":"unknown"}""")
+
+            val result = networkService.makeRequest<SuccessData, FailureData>(
+                request,
+                json = strictJson,
+            )
+
+            val failure = result.expectFailure()
+            assertNull(failure.body)
+            assertInstanceOf(ApiResponseException::class.java, failure.error)
+        }
+
+    @Test
+    fun `sample runs`() = runTest {
+        givenFailureResponse()
+        networkServiceParseFailureSample(request, networkService)
+    }
+
+    private fun givenFailureResponse(
+        body: String = """{"errorCode":123}""",
+    ) {
+        httpClient.exception = GenericResponseException(
+            response = GenericHttpResponse(
+                status = failureStatus,
+                body = body,
+            ),
+            cause = IllegalStateException("$failureStatus"),
+        )
+    }
+
+}
+
+@Serializable
+private data class SuccessData(
+    val subject: String,
+    val message: String,
+)
+
+@Serializable
+private data class FailureData(
+    val errorCode: Int,
+)

--- a/network/src/test/java/uk/gov/android/network/service/v2/NetworkServiceTypedSuccessExtTest.kt
+++ b/network/src/test/java/uk/gov/android/network/service/v2/NetworkServiceTypedSuccessExtTest.kt
@@ -1,0 +1,125 @@
+package uk.gov.android.network.service.v2
+
+import kotlinx.coroutines.test.runTest
+import kotlinx.io.IOException
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import uk.gov.android.network.api.v2.ApiRequest
+import uk.gov.android.network.api.v3.ApiResponseAssertions.expectFailure
+import uk.gov.android.network.api.v3.ApiResponseAssertions.expectSuccess
+import uk.gov.android.network.client.v2.GenericHttpResponse
+import uk.gov.android.network.client.v2.StubHttpClient
+import uk.gov.android.network.service.ApiResponseException
+import uk.gov.android.network.service.TransportException
+import uk.gov.android.network.service.json.JsonDefaults
+import uk.gov.android.network.service.v2.NetworkServiceTypedSuccessExt.makeRequest
+
+class NetworkServiceTypedSuccessExtTest {
+    private val httpClient = StubHttpClient()
+    private val networkService = DefaultNetworkService(httpClient = httpClient)
+    private val request = ApiRequest.Get(url = "https://example.com")
+    private val customStrictJson = Json { ignoreUnknownKeys = false }
+
+    @Test
+    fun `given valid json response, makeRequest returns parsed object`() =
+        runTest {
+            givenSuccessResponse()
+
+            val result = networkService.makeRequest<TestData>(request)
+
+            val success = result.expectSuccess()
+            assertEquals(TestData("Test", "Hello"), success.body)
+            assertEquals(200, success.status)
+        }
+
+    @Test
+    fun `given valid json response with unknown key, makeRequest returns parsed object`() =
+        runTest {
+            givenSuccessResponse("""{"subject":"Test","message":"Hello","new":"value"}""")
+
+            val result = networkService.makeRequest<TestData>(request)
+
+            val success = result.expectSuccess()
+            assertEquals(TestData("Test", "Hello"), success.body)
+            assertEquals(200, success.status)
+        }
+
+    @Test
+    fun `when Json is provided, makeRequest uses the given implementation`() =
+        runTest {
+            // First check that our custom Json is stricter
+            assertTrue(
+                customStrictJson.configuration.ignoreUnknownKeys !=
+                        JsonDefaults.jsonDecoder.configuration.ignoreUnknownKeys
+            )
+            givenSuccessResponse(
+                body = """{"subject":"Test","message":"Hello","new":"Hello"}"""
+            )
+
+            val result = networkService.makeRequest<TestData>(request, json = customStrictJson)
+
+            val failure = result.expectFailure()
+            assertInstanceOf(ApiResponseException::class.java, failure.error)
+        }
+
+    @Test
+    fun `given upstream failure, makeRequest returns failure`() =
+        runTest {
+            httpClient.exception = IOException("connection failed")
+
+            val result = networkService.makeRequest<TestData>(request)
+
+            val failure = result.expectFailure()
+            assertInstanceOf(TransportException::class.java, failure.error)
+        }
+
+    @Test
+    fun `given invalid json, makeRequest returns api response failure`() =
+        runTest {
+            givenSuccessResponse("not json")
+
+            val result = networkService.makeRequest<TestData>(request)
+
+            val failure = result.expectFailure()
+            assertInstanceOf(ApiResponseException::class.java, failure.error)
+        }
+
+    @Test
+    fun `given json with wrong structure, makeRequest returns api response failure`() =
+        runTest {
+            givenSuccessResponse("""{"unexpected":"structure"}""")
+
+            val result = networkService.makeRequest<TestData>(request)
+
+            val failure = result.expectFailure()
+            assertEquals(
+                "Failed to parse response body as class uk.gov.android.network.service.v2.TestData",
+                failure.error.message,
+            )
+            assertInstanceOf(ApiResponseException::class.java, failure.error)
+        }
+
+    @Test
+    fun `sample runs`() = runTest {
+        givenSuccessResponse()
+        networkServiceParseSuccessSample(request, networkService)
+    }
+
+    private fun givenSuccessResponse(
+        body: String = """{"subject":"Test","message":"Hello"}"""
+    ) {
+        httpClient.response =
+            GenericHttpResponse(status = 200, body = body)
+
+    }
+}
+
+@Serializable
+private data class TestData(
+    val subject: String,
+    val message: String,
+)

--- a/network/src/testFixtures/java/uk/gov/android/network/api/v3/ApiResponseAssertions.kt
+++ b/network/src/testFixtures/java/uk/gov/android/network/api/v3/ApiResponseAssertions.kt
@@ -1,0 +1,18 @@
+package uk.gov.android.network.api.v3
+
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+
+object ApiResponseAssertions {
+    fun <F> ApiResponse<*, F, *>.expectFailure(): ApiResponse.Failure<F, *> {
+        assertInstanceOf(
+            ApiResponse.Failure::class.java,
+            this,
+        )
+        return this as ApiResponse.Failure<F, *>
+    }
+
+    fun <T, F> ApiResponse<T, F, *>.expectSuccess(): ApiResponse.Success<T> {
+        assertInstanceOf(ApiResponse.Success::class.java, this)
+        return this as ApiResponse.Success<T>
+    }
+}


### PR DESCRIPTION
## Context

Lets consumers get the response body, both raw and typed, from failed API calls (3xx, 4xx, 5xx).

DCMAW-21605

## Release notes

You can now access the response body when requests fail (and the response is available) by using `NetworkService` version 2:

```kt
val response = networkService.makeRequest(request)

val failureBody = (response as? ApiResponse.Failure)?.body
```

You can now parse typed responses for both success and failures:

```kt
val response = networkService.makeRequest<CustomSuccess, CustomFailure>(request)

// If you don't need to parse the response body types, these still work:
networkService.makeRequest<CustomSuccess>(request) // Failure bodies aren't parsed
networkService.makeRequest(request)                // Response bodies aren't parsed
```


### How to upgrade

If you use `NetworkService` or `DefaultNetworkService`, migrate to the `uk.gov.android.network.service.v2` equivalents.

If you use `NetworkServiceJsonExt` extensions, migrate to `NetworkServiceTypedSuccessExt` or `NetworkServiceTypedFailureExt`.

If you use `ApiResponse` v2, migrate to the `uk.gov.android.network.api.v3` equivalent. `ApiResponse` v3 adds a new type parameter for the failure response body type.

If you use `ApiResponse.Success.response`, use `ApiResponse.Success.body` instead.

## Evidence of the change:

[//]: # (Screenshots / uploaded videos go here)

## Checklist

### Before creating the pull request

- [ ] Commit messages that conform to conventional commit messages.
- [ ] Tests pass locally.
- [ ] Pull request has a clear title with a short description about the feature or update.
- [ ] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [x] Complete all Acceptance Criteria within Jira ticket.
- [x] Self-review code.
- [ ] Complete automated Testing:
  * [x] Unit Tests.
  * [ ] Integration Tests.
  * [ ] Instrumentation / Emulator Tests.
- [ ] Handle PR comments.

### Before merging the pull request

- [ ] For **Defect**, **Tech Story** and **Story** tickets: Make sure that QA has reviewed (by checking they have the correct links to the correct JIRA tickets, the correct amount of details in the PR description to match the JIRA ticket, screenshot/video evidence attached when necessary) and commented QA approval.
- [ ] For **Tech Debt**, **Task** and **Spike** tickets (dev-only): Make sure that developer has reviewed (by checking they have the correct links to the correct JIRA tickets, the correct amount of details in the PR description to match the JIRA ticket, screenshot/video evidence attached when necessary) and commented Dev QA approval.
- [ ] [Sonar cloud report] passes inspections for your PR.
- [ ] Resolve all comments.

[Sonar cloud report]: https://sonarcloud.io/project/overview?id=mobile-android-networking
